### PR TITLE
결제 만료 스케줄러 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ stateDiagram-v2
     CREATED --> EXPIRED: 결제 미초기화 10분 경과 (스케줄러)
     PENDING --> PAID: 결제 승인 (payment.approved)
     PENDING --> ABORTED: 결제 실패 (payment.failed)
+    PENDING --> EXPIRED: 결제 만료 (payment.expired)
     PENDING --> FAILED: 시스템 오류
 ```
 
@@ -108,6 +109,7 @@ stateDiagram-v2
     IN_PROGRESS --> FAILED: PG 승인 실패
     IN_PROGRESS --> ABORTED: PG 결과 불확실
     REQUESTED --> FAILED: PG 직접 실패 콜백
+    REQUESTED --> FAILED: 결제 만료 (스케줄러)
     APPROVED --> CANCELED: 결제 취소
 ```
 
@@ -150,6 +152,7 @@ dev.labs.commerce.{service}
 | `payment.initialized`      | payment-service   | order-service     |
 | `payment.approved`         | payment-service   | order-service     |
 | `payment.failed`           | payment-service   | order-service     |
+| `payment.expired`          | payment-service   | order-service     |
 
 ### 주문 만료 스케줄러
 
@@ -160,6 +163,17 @@ dev.labs.commerce.{service}
 - inventory-service는 이벤트를 수신해 해당 주문의 재고 예약을 해제하며, 예약이 없는 경우 멱등하게 skip 처리
 
 만료 기준 시간은 `order.expiry.pending-expiry-minutes`(기본값 10분)로 조정 가능하다.
+
+### 결제 만료 스케줄러
+
+사용자가 PG 결제창에서 이탈하거나 시간 초과가 발생하면 결제 레코드가 `REQUESTED` 상태로 방치될 수 있다. 이를 처리하기 위해 payment-service에 만료 스케줄러를 구현했다.
+
+- 1분 주기로 실행되며, `REQUESTED` 상태인 결제 중 요청 시각 기준 30분을 초과한 것을 만료 대상으로 조회
+- 대상 결제를 `FAILED`(`failureCode=PAYMENT_EXPIRED`)로 상태 전이하고 `payment.expired` 이벤트 발행
+- order-service는 이벤트를 수신해 해당 주문을 `EXPIRED`로 전이하고 `order.expired` 이벤트 발행
+- inventory-service는 `order.expired`를 수신해 재고 예약을 해제
+
+만료 기준 시간은 `payment.expiry.requested-expiry-minutes`(기본값 30분)로 조정 가능하다.
 
 ### Mock PG 게이트웨이
 

--- a/service/order-service/src/main/java/dev/labs/commerce/order/api/messaging/PaymentEventsConsumer.java
+++ b/service/order-service/src/main/java/dev/labs/commerce/order/api/messaging/PaymentEventsConsumer.java
@@ -4,14 +4,17 @@ import com.fasterxml.jackson.databind.JsonNode;
 import dev.labs.commerce.common.event.EventEnvelope;
 import dev.labs.commerce.common.event.EventPayloadConverter;
 import dev.labs.commerce.order.api.messaging.dto.PaymentApprovedEvent;
+import dev.labs.commerce.order.api.messaging.dto.PaymentExpiredEvent;
 import dev.labs.commerce.order.api.messaging.dto.PaymentFailedEvent;
 import dev.labs.commerce.order.api.messaging.dto.PaymentInitializedEvent;
 import dev.labs.commerce.order.core.order.application.usecase.AbortOrderByPaymentFailureUseCase;
 import dev.labs.commerce.order.core.order.application.usecase.ConfirmPaidUseCase;
 import dev.labs.commerce.order.core.order.application.usecase.ConfirmPaymentInitializedUseCase;
+import dev.labs.commerce.order.core.order.application.usecase.ExpireOrderUseCase;
 import dev.labs.commerce.order.core.order.application.usecase.dto.AbortOrderByPaymentFailureCommand;
 import dev.labs.commerce.order.core.order.application.usecase.dto.ConfirmPaidCommand;
 import dev.labs.commerce.order.core.order.application.usecase.dto.ConfirmPaymentInitializedCommand;
+import dev.labs.commerce.order.core.order.application.usecase.dto.ExpireOrderCommand;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -62,4 +65,17 @@ public class PaymentEventsConsumer {
             abortOrderByPaymentFailureUseCase.execute(new AbortOrderByPaymentFailureCommand(event.orderId()));
         };
     }
+
+    @Bean
+    public Consumer<EventEnvelope<JsonNode>> onPaymentExpired(
+            ExpireOrderUseCase expireOrderUseCase,
+            EventPayloadConverter eventPayloadConverter
+    ) {
+        return envelope -> {
+            PaymentExpiredEvent event = eventPayloadConverter.convert(envelope.payload(), PaymentExpiredEvent.class);
+            log.info("Received PaymentExpiredEvent: orderId={}", event.orderId());
+            expireOrderUseCase.execute(new ExpireOrderCommand(event.orderId()));
+        };
+    }
+
 }

--- a/service/order-service/src/main/java/dev/labs/commerce/order/api/messaging/dto/PaymentExpiredEvent.java
+++ b/service/order-service/src/main/java/dev/labs/commerce/order/api/messaging/dto/PaymentExpiredEvent.java
@@ -1,0 +1,8 @@
+package dev.labs.commerce.order.api.messaging.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PaymentExpiredEvent(
+        @NotBlank String orderId
+) {
+}

--- a/service/order-service/src/main/resources/application.yml
+++ b/service/order-service/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
 
   cloud:
     function:
-      definition: onStockReservationFailed;onPaymentInitialized;onPaymentApproved;onPaymentFailed
+      definition: onStockReservationFailed;onPaymentInitialized;onPaymentApproved;onPaymentFailed;onPaymentExpired
     stream:
       kafka:
         binder:
@@ -51,6 +51,10 @@ spring:
           content-type: application/json
         onPaymentFailed-in-0:
           destination: payment.failed
+          group: order-service
+          content-type: application/json
+        onPaymentExpired-in-0:
+          destination: payment.expired
           group: order-service
           content-type: application/json
 

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/api/scheduling/PaymentExpiryScheduler.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/api/scheduling/PaymentExpiryScheduler.java
@@ -1,0 +1,44 @@
+package dev.labs.commerce.payment.api.scheduling;
+
+import dev.labs.commerce.payment.core.payment.application.usecase.ExpirePaymentUseCase;
+import dev.labs.commerce.payment.core.payment.application.usecase.dto.ExpirePaymentCommand;
+import dev.labs.commerce.payment.core.payment.domain.PaymentDao;
+import dev.labs.commerce.payment.core.payment.domain.PaymentStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentExpiryScheduler {
+
+    private static final int EXPIRATION_THRESHOLD_MINUTES = 30;
+
+    private final PaymentDao paymentDao;
+    private final ExpirePaymentUseCase expirePaymentUseCase;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void expirePayments() {
+        Instant threshold = Instant.now().minus(EXPIRATION_THRESHOLD_MINUTES, ChronoUnit.MINUTES);
+        List<String> paymentIds = paymentDao.findIdsByStatusAndRequestedAtBefore(PaymentStatus.REQUESTED, threshold);
+
+        if (paymentIds.isEmpty()) {
+            return;
+        }
+
+        log.info("Expiring {} payments older than {} minutes", paymentIds.size(), EXPIRATION_THRESHOLD_MINUTES);
+        paymentIds.forEach(paymentId -> {
+            try {
+                expirePaymentUseCase.execute(new ExpirePaymentCommand(paymentId));
+            } catch (Exception e) {
+                log.error("Failed to expire payment: paymentId={}", paymentId, e);
+            }
+        });
+    }
+}

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/api/scheduling/PaymentExpiryScheduler.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/api/scheduling/PaymentExpiryScheduler.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.payment.api.scheduling;
 
+import dev.labs.commerce.payment.config.PaymentExpiryProperties;
 import dev.labs.commerce.payment.core.payment.application.usecase.ExpirePaymentUseCase;
 import dev.labs.commerce.payment.core.payment.application.usecase.dto.ExpirePaymentCommand;
 import dev.labs.commerce.payment.core.payment.domain.PaymentDao;
@@ -18,21 +19,20 @@ import java.util.List;
 @Slf4j
 public class PaymentExpiryScheduler {
 
-    private static final int EXPIRATION_THRESHOLD_MINUTES = 30;
-
     private final PaymentDao paymentDao;
     private final ExpirePaymentUseCase expirePaymentUseCase;
+    private final PaymentExpiryProperties properties;
 
     @Scheduled(fixedDelay = 60_000)
     public void expirePayments() {
-        Instant threshold = Instant.now().minus(EXPIRATION_THRESHOLD_MINUTES, ChronoUnit.MINUTES);
+        Instant threshold = Instant.now().minus(properties.getRequestedExpiryMinutes(), ChronoUnit.MINUTES);
         List<String> paymentIds = paymentDao.findIdsByStatusAndRequestedAtBefore(PaymentStatus.REQUESTED, threshold);
 
         if (paymentIds.isEmpty()) {
             return;
         }
 
-        log.info("Expiring {} payments older than {} minutes", paymentIds.size(), EXPIRATION_THRESHOLD_MINUTES);
+        log.info("Expiring {} payments older than {} minutes", paymentIds.size(), properties.getRequestedExpiryMinutes());
         paymentIds.forEach(paymentId -> {
             try {
                 expirePaymentUseCase.execute(new ExpirePaymentCommand(paymentId));

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/config/PaymentExpiryConfig.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/config/PaymentExpiryConfig.java
@@ -1,0 +1,11 @@
+package dev.labs.commerce.payment.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableConfigurationProperties(PaymentExpiryProperties.class)
+@EnableScheduling
+public class PaymentExpiryConfig {
+}

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/config/PaymentExpiryProperties.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/config/PaymentExpiryProperties.java
@@ -1,0 +1,12 @@
+package dev.labs.commerce.payment.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "payment.expiry")
+@Getter
+@Setter
+public class PaymentExpiryProperties {
+    private int requestedExpiryMinutes = 30;
+}

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/event/PaymentEventPublisher.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/event/PaymentEventPublisher.java
@@ -8,4 +8,6 @@ public interface PaymentEventPublisher {
 
     void publishPaymentFailed(PaymentFailedEvent event);
 
+    void publishPaymentExpired(PaymentExpiredEvent event);
+
 }

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/event/PaymentExpiredEvent.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/event/PaymentExpiredEvent.java
@@ -1,0 +1,17 @@
+package dev.labs.commerce.payment.core.payment.application.event;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record PaymentExpiredEvent(
+        String paymentId,
+        String orderId,
+        long customerId,
+        Instant expiredAt
+) {
+    public PaymentExpiredEvent {
+        Objects.requireNonNull(paymentId, "paymentId must not be null");
+        Objects.requireNonNull(orderId, "orderId must not be null");
+        Objects.requireNonNull(expiredAt, "expiredAt must not be null");
+    }
+}

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/usecase/ExpirePaymentUseCase.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/usecase/ExpirePaymentUseCase.java
@@ -1,7 +1,7 @@
 package dev.labs.commerce.payment.core.payment.application.usecase;
 
 import dev.labs.commerce.payment.core.payment.application.event.PaymentEventPublisher;
-import dev.labs.commerce.payment.core.payment.application.event.PaymentFailedEvent;
+import dev.labs.commerce.payment.core.payment.application.event.PaymentExpiredEvent;
 import dev.labs.commerce.payment.core.payment.application.usecase.dto.ExpirePaymentCommand;
 import dev.labs.commerce.payment.core.payment.domain.Payment;
 import dev.labs.commerce.payment.core.payment.domain.PaymentRepository;
@@ -26,15 +26,14 @@ public class ExpirePaymentUseCase {
         Payment payment = paymentRepository.findById(command.paymentId())
                 .orElseThrow(() -> new PaymentNotFoundException(command.paymentId()));
 
-        payment.fail("PAYMENT_EXPIRED", null, Instant.now());
+        Instant now = Instant.now();
+        payment.fail("PAYMENT_EXPIRED", null, now);
 
-        eventPublisher.publishPaymentFailed(new PaymentFailedEvent(
+        eventPublisher.publishPaymentExpired(new PaymentExpiredEvent(
                 payment.getPaymentId(),
                 payment.getOrderId(),
                 payment.getCustomerId(),
-                payment.getFailureCode(),
-                payment.getFailureMessage(),
-                payment.getFailedAt()
+                now
         ));
 
         log.info("Payment expired: paymentId={}", payment.getPaymentId());

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/usecase/ExpirePaymentUseCase.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/usecase/ExpirePaymentUseCase.java
@@ -1,0 +1,42 @@
+package dev.labs.commerce.payment.core.payment.application.usecase;
+
+import dev.labs.commerce.payment.core.payment.application.event.PaymentEventPublisher;
+import dev.labs.commerce.payment.core.payment.application.event.PaymentFailedEvent;
+import dev.labs.commerce.payment.core.payment.application.usecase.dto.ExpirePaymentCommand;
+import dev.labs.commerce.payment.core.payment.domain.Payment;
+import dev.labs.commerce.payment.core.payment.domain.PaymentRepository;
+import dev.labs.commerce.payment.core.payment.domain.exception.PaymentNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class ExpirePaymentUseCase {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentEventPublisher eventPublisher;
+
+    public void execute(ExpirePaymentCommand command) {
+        Payment payment = paymentRepository.findById(command.paymentId())
+                .orElseThrow(() -> new PaymentNotFoundException(command.paymentId()));
+
+        payment.fail("PAYMENT_EXPIRED", null, Instant.now());
+
+        eventPublisher.publishPaymentFailed(new PaymentFailedEvent(
+                payment.getPaymentId(),
+                payment.getOrderId(),
+                payment.getCustomerId(),
+                payment.getFailureCode(),
+                payment.getFailureMessage(),
+                payment.getFailedAt()
+        ));
+
+        log.info("Payment expired: paymentId={}", payment.getPaymentId());
+    }
+}

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/usecase/dto/ExpirePaymentCommand.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/application/usecase/dto/ExpirePaymentCommand.java
@@ -1,0 +1,4 @@
+package dev.labs.commerce.payment.core.payment.application.usecase.dto;
+
+public record ExpirePaymentCommand(String paymentId) {
+}

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/domain/PaymentDao.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/domain/PaymentDao.java
@@ -1,0 +1,10 @@
+package dev.labs.commerce.payment.core.payment.domain;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface PaymentDao {
+
+    List<String> findIdsByStatusAndRequestedAtBefore(PaymentStatus status, Instant threshold);
+
+}

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/infra/messaging/KafkaPaymentEventPublisher.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/infra/messaging/KafkaPaymentEventPublisher.java
@@ -5,6 +5,7 @@ import dev.labs.commerce.common.event.EventPublisher;
 import dev.labs.commerce.payment.core.payment.application.event.PaymentEventPublisher;
 import dev.labs.commerce.payment.core.payment.application.event.PaymentInitializedEvent;
 import dev.labs.commerce.payment.core.payment.application.event.PaymentApprovedEvent;
+import dev.labs.commerce.payment.core.payment.application.event.PaymentExpiredEvent;
 import dev.labs.commerce.payment.core.payment.application.event.PaymentFailedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,7 @@ public class KafkaPaymentEventPublisher implements PaymentEventPublisher {
     private static final String PAYMENT_INITIALIZED_BINDING = "payment-initialized-out-0";
     private static final String PAYMENT_APPROVED_BINDING = "payment-approved-out-0";
     private static final String PAYMENT_FAILED_BINDING = "payment-failed-out-0";
+    private static final String PAYMENT_EXPIRED_BINDING = "payment-expired-out-0";
 
     private final EventPublisher eventPublisher;
 
@@ -58,6 +60,20 @@ public class KafkaPaymentEventPublisher implements PaymentEventPublisher {
                         PAYMENT_FAILED_BINDING,
                         event.paymentId(),
                         EventEnvelope.of(event, PaymentFailedEvent.class)
+                );
+            }
+        });
+    }
+
+    @Override
+    public void publishPaymentExpired(PaymentExpiredEvent event) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                eventPublisher.publish(
+                        PAYMENT_EXPIRED_BINDING,
+                        event.paymentId(),
+                        EventEnvelope.of(event, PaymentExpiredEvent.class)
                 );
             }
         });

--- a/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/infra/persistence/PaymentDaoImpl.java
+++ b/service/payment-service/src/main/java/dev/labs/commerce/payment/core/payment/infra/persistence/PaymentDaoImpl.java
@@ -1,0 +1,30 @@
+package dev.labs.commerce.payment.core.payment.infra.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dev.labs.commerce.payment.core.payment.domain.PaymentDao;
+import dev.labs.commerce.payment.core.payment.domain.PaymentStatus;
+import dev.labs.commerce.payment.core.payment.domain.QPayment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentDaoImpl implements PaymentDao {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public List<String> findIdsByStatusAndRequestedAtBefore(PaymentStatus status, Instant threshold) {
+        return factory.select(QPayment.payment.paymentId)
+                .from(QPayment.payment)
+                .where(
+                        QPayment.payment.status.eq(status),
+                        QPayment.payment.requestedAt.before(threshold)
+                )
+                .fetch();
+    }
+
+}

--- a/service/payment-service/src/main/resources/application.yml
+++ b/service/payment-service/src/main/resources/application.yml
@@ -35,6 +35,9 @@ spring:
         payment-failed-out-0:
           destination: payment.failed
           content-type: application/json
+        payment-expired-out-0:
+          destination: payment.expired
+          content-type: application/json
 
 management:
   tracing:

--- a/service/payment-service/src/main/resources/application.yml
+++ b/service/payment-service/src/main/resources/application.yml
@@ -67,3 +67,7 @@ service:
       base-url: http://localhost:20102
       connect-timeout: 3000
       read-timeout: 5000
+
+payment:
+  expiry:
+    requested-expiry-minutes: 30


### PR DESCRIPTION

## 문제

사용자가 PG 결제창에서 이탈하거나 시간 초과가 발생하면 결제 레코드가 `REQUESTED` 상태로 방치된다. payment-service에는 이를 감지해 처리하는 수단이 없었고, 주문은 `PENDING`, 재고는 예약 상태로 무기한 묶였다.

## 해결 방법

payment-service에 만료 스케줄러를 추가해 일정 시간 이상 `REQUESTED`로 남은 결제를 주기적으로 만료 처리한다.

**흐름**

```
PaymentExpiryScheduler (1분 주기)
  → PaymentDao.findIdsByStatusAndRequestedAtBefore(REQUESTED, now - 30분)
  → ExpirePaymentUseCase (단건, 독립 트랜잭션)
      → payment.fail("PAYMENT_EXPIRED")
      → payment.expired 이벤트 발행
  → order-service: 주문 EXPIRED 전이 + order.expired 발행
  → inventory-service: 재고 예약 해제
```

**payment.failed 재사용 대신 payment.expired 신규 토픽을 선택한 이유**

order-service에 `EXPIRED` 상태와 `markAsExpired()` 전이가 이미 별도로 존재한다. PG 거절(`ABORTED`)과 만료는 업무 의미가 다르고 다운스트림 상태 전이도 달라야 하므로 토픽을 분리했다.

---

## 변경 범위

**payment-service**
- `ExpirePaymentUseCase` — 단건 만료 처리 (`REQUESTED → FAILED`, `payment.expired` 발행)
- `PaymentExpiredEvent` — 신규 이벤트
- `PaymentExpiryScheduler` — 1분 주기 스케줄러 (`api/scheduling`), 결제 요청 후 30분 후 만료처리

**order-service**

- `PaymentEventsConsumer.onPaymentExpired` — `payment.expired` 구독, 기존 `ExpireOrderUseCase` 재사용
- `application.yml` — `onPaymentExpired` function definition 및 바인딩 추가

## 관련 이슈

Closes #35 