### PR TITLE
feat(product): DRAFT 상태·카탈로그 필드 도입으로 Product 모델 확장

### DIFF
--- a/service/product-service/README.md
+++ b/service/product-service/README.md
@@ -12,9 +12,9 @@
 | 용어                        | 정의                                       | 비고                                   |
 |:--------------------------|:-----------------------------------------|:-------------------------------------|
 | **Product (상품)**          | 판매의 최소 단위. 이름, 가격, 통화, 설명 정보를 가짐.        |                                      |
-| **ProductStatus (상품 상태)** | 상품의 노출 및 판매 가능 여부를 결정하는 상태.              | `INACTIVE`, `ACTIVE`, `DISCONTINUED` |
+| **ProductStatus (상품 상태)** | 상품의 노출 및 판매 가능 여부를 결정하는 상태.              | `DRAFT`, `INACTIVE`, `ACTIVE`, `DISCONTINUED` |
 | **Price (가격)**            | 상품의 판매 금액. 0원 이상이어야 함.                   | 음수 불가                                |
-| **Discontinued (단종)**     | 더 이상 판매하지 않으며, 정보 수정 및 재활성화가 불가능한 최종 상태. |                                      |
+| **Discontinued (판매 종료)** | 더 이상 판매하지 않으며, 정보 수정 및 재활성화가 불가능한 최종 상태. |                                      |
 
 ---
 
@@ -28,7 +28,8 @@
 ### 3.2 상태 기반 수정 제한
 
 - **수정 불가**: 상품 상태가 **`DISCONTINUED`**인 경우, 상품 이름, 가격 등 모든 기본 정보의 수정을 차단합니다.
-- **재활성화 불가**: 한 번 `DISCONTINUED` 상태로 변경된 상품은 다시 `ACTIVE` 또는 `INACTIVE` 상태로 되돌릴 수 없습니다. (영구적 단종)
+- **재활성화 불가**: 한 번 `DISCONTINUED` 상태로 변경된 상품은 다시 `ACTIVE` 또는 `INACTIVE` 상태로 되돌릴 수 없습니다. (영구적 판매 종료)
+- **`DRAFT → INACTIVE` 금지**: `INACTIVE`는 "한 번 이상 활성화됐던 상품이 중단된 상태"를 의미하므로, 아직 한 번도 판매되지 않은 `DRAFT` 상태에서는 `INACTIVE`로 바로 전이할 수 없습니다.
 
 ---
 
@@ -38,17 +39,20 @@
 
 ```mermaid
 stateDiagram-v2
-    [*] --> INACTIVE: 상품 등록 (Initial)
-    INACTIVE --> ACTIVE: 판매 시작 (활성화)
-    ACTIVE --> INACTIVE: 임시 중단 (비활성화)
-    INACTIVE --> DISCONTINUED: 판매 종료 (단종)
-    ACTIVE --> DISCONTINUED: 즉시 단종
+    [*] --> DRAFT: 상품 등록 (Initial)
+    DRAFT --> ACTIVE: 검수 완료 후 판매 시작
+    DRAFT --> DISCONTINUED: 검수 중 취소/폐기
+    ACTIVE --> INACTIVE: 수동 판매 중단
+    ACTIVE --> DISCONTINUED: 즉시 판매 종료
+    INACTIVE --> ACTIVE: 판매 재개
+    INACTIVE --> DISCONTINUED: 판매 종료
     DISCONTINUED --> [*]: 최종 상태 (수정/복구 불가)
 ```
 
-1. **INACTIVE (비활성화)**: 최초 등록 시의 기본 상태입니다. 내부 검수 중이거나 일시적으로 판매를 중단할 때 사용합니다.
-2. **ACTIVE (활성화)**: 사용자에게 노출되며 실제 주문이 가능한 판매 중 상태입니다.
-3. **DISCONTINUED (단종)**: 상품의 판매가 영구적으로 종료된 상태입니다.
+1. **DRAFT (임시 저장)**: 최초 등록 시의 기본 상태입니다. 내부 검수 및 판매 준비 중인 단계로, 아직 한 번도 판매된 적이 없는 상품을 의미합니다.
+2. **INACTIVE (판매 중단)**: 한 번 이상 활성화됐던 상품의 판매를 일시 중단한 상태입니다. `ACTIVE`에서만 진입할 수 있습니다.
+3. **ACTIVE (판매 중)**: 사용자에게 노출되며 실제 주문이 가능한 판매 중 상태입니다.
+4. **DISCONTINUED (판매 종료)**: 상품의 판매가 영구적으로 종료된 상태입니다.
     - **핵심 로직**: `DISCONTINUED` 상태는 터미널(Terminal) 상태로, 이 상태에 진입하면 상태 복구가 불가능하며 정보 수정도 제한됩니다.
 
 ---
@@ -58,7 +62,7 @@ stateDiagram-v2
 ### 상품 등록 (Create)
 
 - 입력: 이름, 가격, 통화, 설명
-- 결과: `INACTIVE` 상태의 상품 생성
+- 결과: `DRAFT` 상태의 상품 생성
 - 검증: 모든 필드 필수 입력, 가격 >= 0
 
 ### 상품 정보 수정 (Modify)
@@ -70,5 +74,5 @@ stateDiagram-v2
 ### 상품 상태 변경 (Change Status)
 
 - 입력: 변경할 목표 상태 (`ProductStatus`)
-- 조건: 현재 상태가 `DISCONTINUED`인 경우 다른 상태로의 변경 차단
+- 조건: 허용된 전이 규칙(`ProductStatus.canTransitionTo`)을 따라야 함. 현재 상태가 `DISCONTINUED`이면 다른 상태로 전이할 수 없고, `DRAFT`에서는 `INACTIVE`로 직접 전이할 수 없음
 - 결과: 상태 값 업데이트

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/ProductRestController.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/ProductRestController.java
@@ -42,7 +42,8 @@ public class ProductRestController {
     public ResponseEntity<ProductResponse> registerProduct(@RequestBody @Valid RegisterProductRequest request) {
         RegisterProductCommand command = new RegisterProductCommand(
                 request.productName(),
-                request.price(),
+                request.listPrice(),
+                request.sellingPrice(),
                 request.currency(),
                 request.description()
         );
@@ -60,7 +61,8 @@ public class ProductRestController {
         ModifyProductCommand command = new ModifyProductCommand(
                 productId,
                 request.productName(),
-                request.price(),
+                request.listPrice(),
+                request.sellingPrice(),
                 request.currency(),
                 request.description()
         );
@@ -116,7 +118,8 @@ public class ProductRestController {
         return new ProductResponse(
                 result.productId(),
                 result.productName(),
-                result.price(),
+                result.listPrice(),
+                result.sellingPrice(),
                 result.currency(),
                 result.productStatus(),
                 result.description(),
@@ -129,7 +132,8 @@ public class ProductRestController {
         return new ProductResponse(
                 result.productId(),
                 result.productName(),
-                result.price(),
+                result.listPrice(),
+                result.sellingPrice(),
                 result.currency(),
                 result.productStatus(),
                 result.description(),
@@ -142,7 +146,8 @@ public class ProductRestController {
         return new ProductResponse(
                 result.productId(),
                 result.productName(),
-                result.price(),
+                result.listPrice(),
+                result.sellingPrice(),
                 result.currency(),
                 result.productStatus(),
                 result.description(),
@@ -155,7 +160,8 @@ public class ProductRestController {
         return new ProductResponse(
                 result.productId(),
                 result.productName(),
-                result.price(),
+                result.listPrice(),
+                result.sellingPrice(),
                 result.currency(),
                 result.productStatus(),
                 result.description(),
@@ -168,7 +174,8 @@ public class ProductRestController {
         return new ProductSummaryResponse(
                 result.productId(),
                 result.productName(),
-                result.price(),
+                result.listPrice(),
+                result.sellingPrice(),
                 result.currency(),
                 result.productStatus()
         );
@@ -178,7 +185,8 @@ public class ProductRestController {
         return new ProductSummaryResponse(
                 result.productId(),
                 result.productName(),
-                result.price(),
+                result.listPrice(),
+                result.sellingPrice(),
                 result.currency(),
                 result.productStatus()
         );

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/ProductRestController.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/ProductRestController.java
@@ -45,6 +45,10 @@ public class ProductRestController {
                 request.listPrice(),
                 request.sellingPrice(),
                 request.currency(),
+                request.category(),
+                request.saleStartAt(),
+                request.saleEndAt(),
+                request.thumbnailUrl(),
                 request.description()
         );
         RegisterProductResult result = registerProductUseCase.execute(command);
@@ -64,6 +68,10 @@ public class ProductRestController {
                 request.listPrice(),
                 request.sellingPrice(),
                 request.currency(),
+                request.category(),
+                request.saleStartAt(),
+                request.saleEndAt(),
+                request.thumbnailUrl(),
                 request.description()
         );
         ModifyProductResult result = modifyProductUseCase.execute(command);
@@ -122,6 +130,10 @@ public class ProductRestController {
                 result.sellingPrice(),
                 result.currency(),
                 result.productStatus(),
+                result.category(),
+                result.saleStartAt(),
+                result.saleEndAt(),
+                result.thumbnailUrl(),
                 result.description(),
                 result.createdAt(),
                 result.updatedAt()
@@ -136,6 +148,10 @@ public class ProductRestController {
                 result.sellingPrice(),
                 result.currency(),
                 result.productStatus(),
+                result.category(),
+                result.saleStartAt(),
+                result.saleEndAt(),
+                result.thumbnailUrl(),
                 result.description(),
                 result.createdAt(),
                 result.updatedAt()
@@ -150,6 +166,10 @@ public class ProductRestController {
                 result.sellingPrice(),
                 result.currency(),
                 result.productStatus(),
+                result.category(),
+                result.saleStartAt(),
+                result.saleEndAt(),
+                result.thumbnailUrl(),
                 result.description(),
                 result.createdAt(),
                 result.updatedAt()
@@ -164,6 +184,10 @@ public class ProductRestController {
                 result.sellingPrice(),
                 result.currency(),
                 result.productStatus(),
+                result.category(),
+                result.saleStartAt(),
+                result.saleEndAt(),
+                result.thumbnailUrl(),
                 result.description(),
                 result.createdAt(),
                 result.updatedAt()
@@ -177,7 +201,9 @@ public class ProductRestController {
                 result.listPrice(),
                 result.sellingPrice(),
                 result.currency(),
-                result.productStatus()
+                result.productStatus(),
+                result.category(),
+                result.thumbnailUrl()
         );
     }
 
@@ -188,7 +214,9 @@ public class ProductRestController {
                 result.listPrice(),
                 result.sellingPrice(),
                 result.currency(),
-                result.productStatus()
+                result.productStatus(),
+                result.category(),
+                result.thumbnailUrl()
         );
     }
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ModifyProductRequest.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ModifyProductRequest.java
@@ -1,14 +1,22 @@
 package dev.labs.commerce.product.api.http.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
 
 public record ModifyProductRequest(
         @NotBlank String productName,
         @NotNull @PositiveOrZero Long listPrice,
         @NotNull @PositiveOrZero Long sellingPrice,
         @NotBlank String currency,
+        @NotNull ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        @Size(max = 500) String thumbnailUrl,
         String description
 ) {
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ModifyProductRequest.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ModifyProductRequest.java
@@ -2,11 +2,12 @@ package dev.labs.commerce.product.api.http.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record ModifyProductRequest(
         @NotBlank String productName,
-        @NotNull @Positive Long price,
+        @NotNull @PositiveOrZero Long listPrice,
+        @NotNull @PositiveOrZero Long sellingPrice,
         @NotBlank String currency,
         String description
 ) {

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ProductResponse.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ProductResponse.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.product.api.http.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import dev.labs.commerce.product.core.product.domain.ProductStatus;
 
 import java.time.Instant;
@@ -11,6 +12,10 @@ public record ProductResponse(
         Long sellingPrice,
         String currency,
         ProductStatus productStatus,
+        ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        String thumbnailUrl,
         String description,
         Instant createdAt,
         Instant updatedAt

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ProductResponse.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ProductResponse.java
@@ -7,7 +7,8 @@ import java.time.Instant;
 public record ProductResponse(
         Long productId,
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         ProductStatus productStatus,
         String description,

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ProductSummaryResponse.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ProductSummaryResponse.java
@@ -5,7 +5,8 @@ import dev.labs.commerce.product.core.product.domain.ProductStatus;
 public record ProductSummaryResponse(
         Long productId,
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         ProductStatus productStatus
 ) {

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ProductSummaryResponse.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/ProductSummaryResponse.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.product.api.http.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import dev.labs.commerce.product.core.product.domain.ProductStatus;
 
 public record ProductSummaryResponse(
@@ -8,6 +9,8 @@ public record ProductSummaryResponse(
         Long listPrice,
         Long sellingPrice,
         String currency,
-        ProductStatus productStatus
+        ProductStatus productStatus,
+        ProductCategory category,
+        String thumbnailUrl
 ) {
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/RegisterProductRequest.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/RegisterProductRequest.java
@@ -2,11 +2,12 @@ package dev.labs.commerce.product.api.http.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record RegisterProductRequest(
         @NotBlank String productName,
-        @NotNull @Positive Long price,
+        @NotNull @PositiveOrZero Long listPrice,
+        @NotNull @PositiveOrZero Long sellingPrice,
         @NotBlank String currency,
         String description
 ) {

--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/RegisterProductRequest.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/http/dto/RegisterProductRequest.java
@@ -1,14 +1,22 @@
 package dev.labs.commerce.product.api.http.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
 
 public record RegisterProductRequest(
         @NotBlank String productName,
         @NotNull @PositiveOrZero Long listPrice,
         @NotNull @PositiveOrZero Long sellingPrice,
         @NotBlank String currency,
+        @NotNull ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        @Size(max = 500) String thumbnailUrl,
         String description
 ) {
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/query/ProductQueryService.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/query/ProductQueryService.java
@@ -27,7 +27,8 @@ public class ProductQueryService {
         return new GetProductResult(
                 product.getProductId(),
                 product.getProductName(),
-                product.getPrice(),
+                product.getListPrice(),
+                product.getSellingPrice(),
                 product.getCurrency(),
                 product.getProductStatus(),
                 product.getDescription(),
@@ -54,7 +55,8 @@ public class ProductQueryService {
                 .map(p -> new ListProductsResult(
                         p.getProductId(),
                         p.getProductName(),
-                        p.getPrice(),
+                        p.getListPrice(),
+                        p.getSellingPrice(),
                         p.getCurrency(),
                         p.getProductStatus()
                 ))
@@ -67,7 +69,8 @@ public class ProductQueryService {
                 .map(p -> new ListProductsByIdsResult(
                         p.getProductId(),
                         p.getProductName(),
-                        p.getPrice(),
+                        p.getListPrice(),
+                        p.getSellingPrice(),
                         p.getCurrency(),
                         p.getProductStatus()
                 ))

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/query/ProductQueryService.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/query/ProductQueryService.java
@@ -31,6 +31,10 @@ public class ProductQueryService {
                 product.getSellingPrice(),
                 product.getCurrency(),
                 product.getProductStatus(),
+                product.getCategory(),
+                product.getSaleStartAt(),
+                product.getSaleEndAt(),
+                product.getThumbnailUrl(),
                 product.getDescription(),
                 product.getCreatedAt(),
                 product.getUpdatedAt()
@@ -52,28 +56,40 @@ public class ProductQueryService {
         }
 
         return products.stream()
-                .map(p -> new ListProductsResult(
-                        p.getProductId(),
-                        p.getProductName(),
-                        p.getListPrice(),
-                        p.getSellingPrice(),
-                        p.getCurrency(),
-                        p.getProductStatus()
-                ))
+                .map(this::toListProductsResult)
                 .collect(Collectors.toList());
     }
 
     public List<ListProductsByIdsResult> listProductsByIds(List<Long> productIds) {
         return productRepository.findAllByProductIdIn(productIds)
                 .stream()
-                .map(p -> new ListProductsByIdsResult(
-                        p.getProductId(),
-                        p.getProductName(),
-                        p.getListPrice(),
-                        p.getSellingPrice(),
-                        p.getCurrency(),
-                        p.getProductStatus()
-                ))
+                .map(this::toListProductsByIdsResult)
                 .toList();
+    }
+
+    private ListProductsResult toListProductsResult(Product p) {
+        return new ListProductsResult(
+                p.getProductId(),
+                p.getProductName(),
+                p.getListPrice(),
+                p.getSellingPrice(),
+                p.getCurrency(),
+                p.getProductStatus(),
+                p.getCategory(),
+                p.getThumbnailUrl()
+        );
+    }
+
+    private ListProductsByIdsResult toListProductsByIdsResult(Product p) {
+        return new ListProductsByIdsResult(
+                p.getProductId(),
+                p.getProductName(),
+                p.getListPrice(),
+                p.getSellingPrice(),
+                p.getCurrency(),
+                p.getProductStatus(),
+                p.getCategory(),
+                p.getThumbnailUrl()
+        );
     }
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ChangeProductStatusUseCase.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ChangeProductStatusUseCase.java
@@ -32,7 +32,8 @@ public class ChangeProductStatusUseCase {
         return new ChangeProductStatusResult(
                 updatedProduct.getProductId(),
                 updatedProduct.getProductName(),
-                updatedProduct.getPrice(),
+                updatedProduct.getListPrice(),
+                updatedProduct.getSellingPrice(),
                 updatedProduct.getCurrency(),
                 updatedProduct.getProductStatus(),
                 updatedProduct.getDescription(),

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ChangeProductStatusUseCase.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ChangeProductStatusUseCase.java
@@ -18,17 +18,13 @@ public class ChangeProductStatusUseCase {
 
     @Transactional
     public ChangeProductStatusResult execute(ChangeProductStatusCommand command) {
-        // Retrieve product
         Product product = productRepository.findById(command.productId())
                 .orElseThrow(() -> new ProductNotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND, "Product not found: " + command.productId()));
 
-        // Change status using domain method
         product.changeStatus(command.status());
 
-        // Persist the changes
         Product updatedProduct = productRepository.save(product);
 
-        // Convert to result
         return new ChangeProductStatusResult(
                 updatedProduct.getProductId(),
                 updatedProduct.getProductName(),
@@ -36,6 +32,10 @@ public class ChangeProductStatusUseCase {
                 updatedProduct.getSellingPrice(),
                 updatedProduct.getCurrency(),
                 updatedProduct.getProductStatus(),
+                updatedProduct.getCategory(),
+                updatedProduct.getSaleStartAt(),
+                updatedProduct.getSaleEndAt(),
+                updatedProduct.getThumbnailUrl(),
                 updatedProduct.getDescription(),
                 updatedProduct.getCreatedAt(),
                 updatedProduct.getUpdatedAt()

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ModifyProductUseCase.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ModifyProductUseCase.java
@@ -25,7 +25,8 @@ public class ModifyProductUseCase {
         // Modify product using domain method
         product.modify(
                 command.productName(),
-                command.price(),
+                command.listPrice(),
+                command.sellingPrice(),
                 command.currency(),
                 command.description()
         );
@@ -37,7 +38,8 @@ public class ModifyProductUseCase {
         return new ModifyProductResult(
                 updatedProduct.getProductId(),
                 updatedProduct.getProductName(),
-                updatedProduct.getPrice(),
+                updatedProduct.getListPrice(),
+                updatedProduct.getSellingPrice(),
                 updatedProduct.getCurrency(),
                 updatedProduct.getProductStatus(),
                 updatedProduct.getDescription(),

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ModifyProductUseCase.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ModifyProductUseCase.java
@@ -18,23 +18,23 @@ public class ModifyProductUseCase {
 
     @Transactional
     public ModifyProductResult execute(ModifyProductCommand command) {
-        // Retrieve product
         Product product = productRepository.findById(command.productId())
                 .orElseThrow(() -> new ProductNotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND, "Product not found: " + command.productId()));
 
-        // Modify product using domain method
         product.modify(
                 command.productName(),
                 command.listPrice(),
                 command.sellingPrice(),
                 command.currency(),
+                command.category(),
+                command.saleStartAt(),
+                command.saleEndAt(),
+                command.thumbnailUrl(),
                 command.description()
         );
 
-        // Persist the changes
         Product updatedProduct = productRepository.save(product);
 
-        // Convert to result
         return new ModifyProductResult(
                 updatedProduct.getProductId(),
                 updatedProduct.getProductName(),
@@ -42,6 +42,10 @@ public class ModifyProductUseCase {
                 updatedProduct.getSellingPrice(),
                 updatedProduct.getCurrency(),
                 updatedProduct.getProductStatus(),
+                updatedProduct.getCategory(),
+                updatedProduct.getSaleStartAt(),
+                updatedProduct.getSaleEndAt(),
+                updatedProduct.getThumbnailUrl(),
                 updatedProduct.getDescription(),
                 updatedProduct.getCreatedAt(),
                 updatedProduct.getUpdatedAt()

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/RegisterProductUseCase.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/RegisterProductUseCase.java
@@ -21,7 +21,8 @@ public class RegisterProductUseCase {
     public RegisterProductResult execute(RegisterProductCommand command) {
         Product product = Product.create(
                 command.productName(),
-                command.price(),
+                command.listPrice(),
+                command.sellingPrice(),
                 command.currency(),
                 command.description()
         );
@@ -35,7 +36,8 @@ public class RegisterProductUseCase {
         return new RegisterProductResult(
                 savedProduct.getProductId(),
                 savedProduct.getProductName(),
-                savedProduct.getPrice(),
+                savedProduct.getListPrice(),
+                savedProduct.getSellingPrice(),
                 savedProduct.getCurrency(),
                 savedProduct.getProductStatus(),
                 savedProduct.getDescription(),

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/RegisterProductUseCase.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/RegisterProductUseCase.java
@@ -24,6 +24,10 @@ public class RegisterProductUseCase {
                 command.listPrice(),
                 command.sellingPrice(),
                 command.currency(),
+                command.category(),
+                command.saleStartAt(),
+                command.saleEndAt(),
+                command.thumbnailUrl(),
                 command.description()
         );
 
@@ -40,6 +44,10 @@ public class RegisterProductUseCase {
                 savedProduct.getSellingPrice(),
                 savedProduct.getCurrency(),
                 savedProduct.getProductStatus(),
+                savedProduct.getCategory(),
+                savedProduct.getSaleStartAt(),
+                savedProduct.getSaleEndAt(),
+                savedProduct.getThumbnailUrl(),
                 savedProduct.getDescription(),
                 savedProduct.getCreatedAt(),
                 savedProduct.getUpdatedAt()

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ChangeProductStatusResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ChangeProductStatusResult.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.product.core.product.application.usecase.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import dev.labs.commerce.product.core.product.domain.ProductStatus;
 
 import java.time.Instant;
@@ -11,6 +12,10 @@ public record ChangeProductStatusResult(
         Long sellingPrice,
         String currency,
         ProductStatus productStatus,
+        ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        String thumbnailUrl,
         String description,
         Instant createdAt,
         Instant updatedAt

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ChangeProductStatusResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ChangeProductStatusResult.java
@@ -7,7 +7,8 @@ import java.time.Instant;
 public record ChangeProductStatusResult(
         Long productId,
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         ProductStatus productStatus,
         String description,

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/GetProductResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/GetProductResult.java
@@ -7,7 +7,8 @@ import java.time.Instant;
 public record GetProductResult(
         Long productId,
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         ProductStatus productStatus,
         String description,

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/GetProductResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/GetProductResult.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.product.core.product.application.usecase.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import dev.labs.commerce.product.core.product.domain.ProductStatus;
 
 import java.time.Instant;
@@ -11,6 +12,10 @@ public record GetProductResult(
         Long sellingPrice,
         String currency,
         ProductStatus productStatus,
+        ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        String thumbnailUrl,
         String description,
         Instant createdAt,
         Instant updatedAt

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ListProductsByIdsResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ListProductsByIdsResult.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.product.core.product.application.usecase.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import dev.labs.commerce.product.core.product.domain.ProductStatus;
 
 public record ListProductsByIdsResult(
@@ -8,6 +9,8 @@ public record ListProductsByIdsResult(
         Long listPrice,
         Long sellingPrice,
         String currency,
-        ProductStatus productStatus
+        ProductStatus productStatus,
+        ProductCategory category,
+        String thumbnailUrl
 ) {
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ListProductsByIdsResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ListProductsByIdsResult.java
@@ -5,7 +5,8 @@ import dev.labs.commerce.product.core.product.domain.ProductStatus;
 public record ListProductsByIdsResult(
         Long productId,
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         ProductStatus productStatus
 ) {

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ListProductsResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ListProductsResult.java
@@ -5,7 +5,8 @@ import dev.labs.commerce.product.core.product.domain.ProductStatus;
 public record ListProductsResult(
         Long productId,
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         ProductStatus productStatus
 ) {

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ListProductsResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ListProductsResult.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.product.core.product.application.usecase.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import dev.labs.commerce.product.core.product.domain.ProductStatus;
 
 public record ListProductsResult(
@@ -8,6 +9,8 @@ public record ListProductsResult(
         Long listPrice,
         Long sellingPrice,
         String currency,
-        ProductStatus productStatus
+        ProductStatus productStatus,
+        ProductCategory category,
+        String thumbnailUrl
 ) {
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ModifyProductCommand.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ModifyProductCommand.java
@@ -1,11 +1,19 @@
 package dev.labs.commerce.product.core.product.application.usecase.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
+
+import java.time.Instant;
+
 public record ModifyProductCommand(
         Long productId,
         String productName,
         Long listPrice,
         Long sellingPrice,
         String currency,
+        ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        String thumbnailUrl,
         String description
 ) {
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ModifyProductCommand.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ModifyProductCommand.java
@@ -3,7 +3,8 @@ package dev.labs.commerce.product.core.product.application.usecase.dto;
 public record ModifyProductCommand(
         Long productId,
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         String description
 ) {

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ModifyProductResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ModifyProductResult.java
@@ -7,7 +7,8 @@ import java.time.Instant;
 public record ModifyProductResult(
         Long productId,
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         ProductStatus productStatus,
         String description,

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ModifyProductResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ModifyProductResult.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.product.core.product.application.usecase.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import dev.labs.commerce.product.core.product.domain.ProductStatus;
 
 import java.time.Instant;
@@ -11,6 +12,10 @@ public record ModifyProductResult(
         Long sellingPrice,
         String currency,
         ProductStatus productStatus,
+        ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        String thumbnailUrl,
         String description,
         Instant createdAt,
         Instant updatedAt

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/RegisterProductCommand.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/RegisterProductCommand.java
@@ -1,10 +1,18 @@
 package dev.labs.commerce.product.core.product.application.usecase.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
+
+import java.time.Instant;
+
 public record RegisterProductCommand(
         String productName,
         Long listPrice,
         Long sellingPrice,
         String currency,
+        ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        String thumbnailUrl,
         String description
 ) {
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/RegisterProductCommand.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/RegisterProductCommand.java
@@ -2,7 +2,8 @@ package dev.labs.commerce.product.core.product.application.usecase.dto;
 
 public record RegisterProductCommand(
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         String description
 ) {

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/RegisterProductResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/RegisterProductResult.java
@@ -7,7 +7,8 @@ import java.time.Instant;
 public record RegisterProductResult(
         Long productId,
         String productName,
-        Long price,
+        Long listPrice,
+        Long sellingPrice,
         String currency,
         ProductStatus productStatus,
         String description,

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/RegisterProductResult.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/RegisterProductResult.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.product.core.product.application.usecase.dto;
 
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
 import dev.labs.commerce.product.core.product.domain.ProductStatus;
 
 import java.time.Instant;
@@ -11,6 +12,10 @@ public record RegisterProductResult(
         Long sellingPrice,
         String currency,
         ProductStatus productStatus,
+        ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        String thumbnailUrl,
         String description,
         Instant createdAt,
         Instant updatedAt

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/Product.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/Product.java
@@ -54,7 +54,7 @@ public class Product extends BaseEntity {
         p.price = price;
         p.currency = currency;
         p.description = description;
-        p.productStatus = ProductStatus.INACTIVE; // 등록 후 활성화
+        p.productStatus = ProductStatus.DRAFT; // 등록 직후 검수/준비 상태
         return p;
     }
 
@@ -69,8 +69,11 @@ public class Product extends BaseEntity {
     }
 
     public void changeStatus(ProductStatus newStatus) {
-        if (this.productStatus == ProductStatus.DISCONTINUED && newStatus != ProductStatus.DISCONTINUED) {
-            throw new InvalidProductStatusException(ProductErrorCode.INVALID_PRODUCT_STATUS, "DISCONTINUED product cannot be reactivated.");
+        if (!this.productStatus.canTransitionTo(newStatus)) {
+            throw new InvalidProductStatusException(
+                    ProductErrorCode.INVALID_PRODUCT_STATUS,
+                    "Cannot change product status from " + this.productStatus + " to " + newStatus + "."
+            );
         }
         this.productStatus = newStatus;
     }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/Product.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/Product.java
@@ -29,8 +29,11 @@ public class Product extends BaseEntity {
     @Column(name = "product_name", nullable = false, length = 200)
     private String productName;
 
-    @Column(name = "price_amount", nullable = false)
-    private Long price;
+    @Column(name = "list_price", nullable = false)
+    private Long listPrice;
+
+    @Column(name = "selling_price", nullable = false)
+    private Long sellingPrice;
 
     @Column(name = "currency", nullable = false, length = 3)
     private String currency;
@@ -43,27 +46,30 @@ public class Product extends BaseEntity {
     private String description;
 
 
-    public static Product create(String name, long price, String currency, String description) {
+    public static Product create(String name, long listPrice, long sellingPrice, String currency, String description) {
         Assert.hasText(name, "productName must not be empty");
-        Assert.isTrue(price >= 0, "price must be zero or greater");
+        validatePrices(listPrice, sellingPrice);
         Assert.hasText(currency, "currency must not be empty");
         Assert.hasText(description, "description must not be empty");
 
         Product p = new Product();
         p.productName = name;
-        p.price = price;
+        p.listPrice = listPrice;
+        p.sellingPrice = sellingPrice;
         p.currency = currency;
         p.description = description;
         p.productStatus = ProductStatus.DRAFT; // 등록 직후 검수/준비 상태
         return p;
     }
 
-    public void modify(String name, long priceAmount, String currency, String description) {
+    public void modify(String name, long listPrice, long sellingPrice, String currency, String description) {
         if (this.productStatus == ProductStatus.DISCONTINUED) {
             throw new InvalidProductStatusException(ProductErrorCode.INVALID_PRODUCT_STATUS, "DISCONTINUED product cannot be updated.");
         }
+        validatePrices(listPrice, sellingPrice);
         this.productName = name;
-        this.price = priceAmount;
+        this.listPrice = listPrice;
+        this.sellingPrice = sellingPrice;
         this.currency = currency;
         this.description = description;
     }
@@ -76,6 +82,12 @@ public class Product extends BaseEntity {
             );
         }
         this.productStatus = newStatus;
+    }
+
+    private static void validatePrices(long listPrice, long sellingPrice) {
+        Assert.isTrue(listPrice >= 0, "listPrice must be zero or greater");
+        Assert.isTrue(sellingPrice >= 0, "sellingPrice must be zero or greater");
+        Assert.isTrue(sellingPrice <= listPrice, "sellingPrice must be less than or equal to listPrice");
     }
 
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/Product.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/Product.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
+import java.time.Instant;
+
 @Entity
 @Table(
         name = "product",
@@ -20,6 +22,8 @@ import org.springframework.util.Assert;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends BaseEntity {
+
+    private static final int THUMBNAIL_URL_MAX_LENGTH = 500;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,14 +46,40 @@ public class Product extends BaseEntity {
     @Column(name = "product_status", nullable = false, length = 30)
     private ProductStatus productStatus;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 50)
+    private ProductCategory category;
+
+    @Column(name = "sale_start_at")
+    private Instant saleStartAt;
+
+    @Column(name = "sale_end_at")
+    private Instant saleEndAt;
+
+    @Column(name = "thumbnail_url", length = THUMBNAIL_URL_MAX_LENGTH)
+    private String thumbnailUrl;
+
     @Column(name = "description", nullable = false, columnDefinition = "text")
     private String description;
 
 
-    public static Product create(String name, long listPrice, long sellingPrice, String currency, String description) {
+    public static Product create(
+            String name,
+            long listPrice,
+            long sellingPrice,
+            String currency,
+            ProductCategory category,
+            Instant saleStartAt,
+            Instant saleEndAt,
+            String thumbnailUrl,
+            String description
+    ) {
         Assert.hasText(name, "productName must not be empty");
         validatePrices(listPrice, sellingPrice);
         Assert.hasText(currency, "currency must not be empty");
+        Assert.notNull(category, "category must not be null");
+        validateSalePeriod(saleStartAt, saleEndAt);
+        validateThumbnailUrl(thumbnailUrl);
         Assert.hasText(description, "description must not be empty");
 
         Product p = new Product();
@@ -57,20 +87,42 @@ public class Product extends BaseEntity {
         p.listPrice = listPrice;
         p.sellingPrice = sellingPrice;
         p.currency = currency;
+        p.category = category;
+        p.saleStartAt = saleStartAt;
+        p.saleEndAt = saleEndAt;
+        p.thumbnailUrl = thumbnailUrl;
         p.description = description;
         p.productStatus = ProductStatus.DRAFT; // 등록 직후 검수/준비 상태
         return p;
     }
 
-    public void modify(String name, long listPrice, long sellingPrice, String currency, String description) {
+    public void modify(
+            String name,
+            long listPrice,
+            long sellingPrice,
+            String currency,
+            ProductCategory category,
+            Instant saleStartAt,
+            Instant saleEndAt,
+            String thumbnailUrl,
+            String description
+    ) {
         if (this.productStatus == ProductStatus.DISCONTINUED) {
             throw new InvalidProductStatusException(ProductErrorCode.INVALID_PRODUCT_STATUS, "DISCONTINUED product cannot be updated.");
         }
         validatePrices(listPrice, sellingPrice);
+        Assert.notNull(category, "category must not be null");
+        validateSalePeriod(saleStartAt, saleEndAt);
+        validateThumbnailUrl(thumbnailUrl);
+
         this.productName = name;
         this.listPrice = listPrice;
         this.sellingPrice = sellingPrice;
         this.currency = currency;
+        this.category = category;
+        this.saleStartAt = saleStartAt;
+        this.saleEndAt = saleEndAt;
+        this.thumbnailUrl = thumbnailUrl;
         this.description = description;
     }
 
@@ -84,10 +136,37 @@ public class Product extends BaseEntity {
         this.productStatus = newStatus;
     }
 
+    public boolean isScheduled() {
+        return this.productStatus == ProductStatus.INACTIVE
+                && this.saleStartAt != null
+                && this.saleStartAt.isAfter(Instant.now());
+    }
+
+    public boolean isSaleExpired() {
+        return this.productStatus == ProductStatus.INACTIVE
+                && this.saleEndAt != null
+                && this.saleEndAt.isBefore(Instant.now());
+    }
+
     private static void validatePrices(long listPrice, long sellingPrice) {
         Assert.isTrue(listPrice >= 0, "listPrice must be zero or greater");
         Assert.isTrue(sellingPrice >= 0, "sellingPrice must be zero or greater");
         Assert.isTrue(sellingPrice <= listPrice, "sellingPrice must be less than or equal to listPrice");
+    }
+
+    private static void validateSalePeriod(Instant saleStartAt, Instant saleEndAt) {
+        if (saleEndAt != null && saleEndAt.isBefore(Instant.now())) {
+            throw new IllegalArgumentException("saleEndAt must not be in the past");
+        }
+        if (saleStartAt != null && saleEndAt != null && !saleStartAt.isBefore(saleEndAt)) {
+            throw new IllegalArgumentException("saleStartAt must be before saleEndAt");
+        }
+    }
+
+    private static void validateThumbnailUrl(String thumbnailUrl) {
+        if (thumbnailUrl != null && thumbnailUrl.length() > THUMBNAIL_URL_MAX_LENGTH) {
+            throw new IllegalArgumentException("thumbnailUrl must not exceed " + THUMBNAIL_URL_MAX_LENGTH + " characters");
+        }
     }
 
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/ProductCategory.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/ProductCategory.java
@@ -1,0 +1,13 @@
+package dev.labs.commerce.product.core.product.domain;
+
+public enum ProductCategory {
+    FIGURE,         // 피규어
+    PLUSH,          // 봉제 인형
+    MODEL_KIT,      // 프라모델/모형 키트
+    TRADING_CARD,   // 트레이딩 카드
+    BOARD_GAME,     // 보드게임
+    DIECAST,        // 다이캐스트
+    PUZZLE,         // 퍼즐
+    ACCESSORY,      // 굿즈/액세서리
+    ETC             // 기타
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/ProductStatus.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/ProductStatus.java
@@ -1,7 +1,20 @@
 package dev.labs.commerce.product.core.product.domain;
 
 public enum ProductStatus {
-    ACTIVE,        // 판매 가능
-    INACTIVE,      // 임시 비활성
-    DISCONTINUED   // 종료 (재판매 불가)
+    DRAFT,         // 등록 직후, 검수/준비 중
+    INACTIVE,      // 판매 중단 (한 번 이상 활성화됐던 상품)
+    ACTIVE,        // 판매 중
+    DISCONTINUED;  // 판매 종료 (재판매 불가)
+
+    public boolean canTransitionTo(ProductStatus target) {
+        if (this == target) {
+            return true;
+        }
+        return switch (this) {
+            case DRAFT -> target == ACTIVE || target == DISCONTINUED;
+            case ACTIVE -> target == INACTIVE || target == DISCONTINUED;
+            case INACTIVE -> target == ACTIVE || target == DISCONTINUED;
+            case DISCONTINUED -> false;
+        };
+    }
 }

--- a/service/product-service/src/main/resources/db/migration/V0__init.sql
+++ b/service/product-service/src/main/resources/db/migration/V0__init.sql
@@ -2,9 +2,14 @@ CREATE TABLE IF NOT EXISTS product
 (
     product_id     BIGSERIAL PRIMARY KEY,
     product_name   VARCHAR(200) NOT NULL,
-    price_amount   BIGINT       NOT NULL,
+    list_price     BIGINT       NOT NULL,
+    selling_price  BIGINT       NOT NULL,
     currency       VARCHAR(3)   NOT NULL,
     product_status VARCHAR(30)  NOT NULL,
+    category       VARCHAR(50)  NOT NULL,
+    sale_start_at  TIMESTAMPTZ,
+    sale_end_at    TIMESTAMPTZ,
+    thumbnail_url  VARCHAR(500),
     description    TEXT         NOT NULL,
     created_at     TIMESTAMPTZ  NOT NULL,
     updated_at     TIMESTAMPTZ  NOT NULL

--- a/service/product-service/src/test/java/dev/labs/commerce/product/core/product/domain/ProductTest.java
+++ b/service/product-service/src/test/java/dev/labs/commerce/product/core/product/domain/ProductTest.java
@@ -20,16 +20,18 @@ class ProductTest {
         void createProduct_withValidInfo_startsAsDraft() {
             // given
             String name = "테스트 상품";
-            long price = 10000L;
+            long listPrice = 10000L;
+            long sellingPrice = 9000L;
             String currency = "KRW";
             String description = "테스트 상품 설명";
 
             // when
-            Product product = Product.create(name, price, currency, description);
+            Product product = Product.create(name, listPrice, sellingPrice, currency, description);
 
             // then
             assertThat(product.getProductName()).isEqualTo(name);
-            assertThat(product.getPrice()).isEqualTo(price);
+            assertThat(product.getListPrice()).isEqualTo(listPrice);
+            assertThat(product.getSellingPrice()).isEqualTo(sellingPrice);
             assertThat(product.getCurrency()).isEqualTo(currency);
             assertThat(product.getDescription()).isEqualTo(description);
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DRAFT);
@@ -42,32 +44,47 @@ class ProductTest {
             String blankName = " ";
 
             // when & then
-            assertThatThrownBy(() -> Product.create(blankName, 10000L, "KRW", "설명"))
+            assertThatThrownBy(() -> Product.create(blankName, 10000L, 10000L, "KRW", "설명"))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
-        @DisplayName("가격이 음수이면 등록할 수 없다")
-        void createProduct_withNegativePrice_throwsException() {
-            // given
-            long negativePrice = -1L;
-
-            // when & then
-            assertThatThrownBy(() -> Product.create("상품명", negativePrice, "KRW", "설명"))
+        @DisplayName("정가가 음수이면 등록할 수 없다")
+        void createProduct_withNegativeListPrice_throwsException() {
+            assertThatThrownBy(() -> Product.create("상품명", -1L, 0L, "KRW", "설명"))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
-        @DisplayName("가격이 0원인 상품은 등록할 수 있다")
-        void createProduct_withZeroPrice_succeeds() {
-            // given
-            long zeroPrice = 0L;
+        @DisplayName("판매가가 음수이면 등록할 수 없다")
+        void createProduct_withNegativeSellingPrice_throwsException() {
+            assertThatThrownBy(() -> Product.create("상품명", 10000L, -1L, "KRW", "설명"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
 
-            // when
-            Product product = Product.create("상품명", zeroPrice, "KRW", "설명");
+        @Test
+        @DisplayName("판매가가 정가보다 크면 등록할 수 없다")
+        void createProduct_whenSellingPriceGreaterThanListPrice_throwsException() {
+            assertThatThrownBy(() -> Product.create("상품명", 10000L, 11000L, "KRW", "설명"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
 
-            // then
-            assertThat(product.getPrice()).isZero();
+        @Test
+        @DisplayName("판매가가 정가와 같으면 등록할 수 있다")
+        void createProduct_whenSellingPriceEqualsListPrice_succeeds() {
+            Product product = Product.create("상품명", 10000L, 10000L, "KRW", "설명");
+
+            assertThat(product.getListPrice()).isEqualTo(10000L);
+            assertThat(product.getSellingPrice()).isEqualTo(10000L);
+        }
+
+        @Test
+        @DisplayName("정가와 판매가가 모두 0원인 상품은 등록할 수 있다")
+        void createProduct_withZeroPrices_succeeds() {
+            Product product = Product.create("상품명", 0L, 0L, "KRW", "설명");
+
+            assertThat(product.getListPrice()).isZero();
+            assertThat(product.getSellingPrice()).isZero();
         }
 
         @Test
@@ -77,7 +94,7 @@ class ProductTest {
             String blankCurrency = " ";
 
             // when & then
-            assertThatThrownBy(() -> Product.create("상품명", 10000L, blankCurrency, "설명"))
+            assertThatThrownBy(() -> Product.create("상품명", 10000L, 10000L, blankCurrency, "설명"))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -88,7 +105,7 @@ class ProductTest {
             String blankDescription = " ";
 
             // when & then
-            assertThatThrownBy(() -> Product.create("상품명", 10000L, "KRW", blankDescription))
+            assertThatThrownBy(() -> Product.create("상품명", 10000L, 10000L, "KRW", blankDescription))
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }
@@ -101,14 +118,15 @@ class ProductTest {
         @DisplayName("DRAFT 상품의 정보를 수정할 수 있다")
         void modifyProduct_whenDraft_succeeds() {
             // given
-            Product product = Product.create("기존 상품명", 10000L, "KRW", "기존 설명");
+            Product product = Product.create("기존 상품명", 10000L, 9000L, "KRW", "기존 설명");
 
             // when
-            product.modify("새 상품명", 20000L, "KRW", "새 설명");
+            product.modify("새 상품명", 20000L, 18000L, "KRW", "새 설명");
 
             // then
             assertThat(product.getProductName()).isEqualTo("새 상품명");
-            assertThat(product.getPrice()).isEqualTo(20000L);
+            assertThat(product.getListPrice()).isEqualTo(20000L);
+            assertThat(product.getSellingPrice()).isEqualTo(18000L);
             assertThat(product.getDescription()).isEqualTo("새 설명");
         }
 
@@ -116,15 +134,16 @@ class ProductTest {
         @DisplayName("판매 중인 상품의 정보를 수정할 수 있다")
         void modifyProduct_whenActive_succeeds() {
             // given
-            Product product = Product.create("기존 상품명", 10000L, "KRW", "기존 설명");
+            Product product = Product.create("기존 상품명", 10000L, 9000L, "KRW", "기존 설명");
             product.changeStatus(ProductStatus.ACTIVE);
 
             // when
-            product.modify("새 상품명", 20000L, "KRW", "새 설명");
+            product.modify("새 상품명", 20000L, 18000L, "KRW", "새 설명");
 
             // then
             assertThat(product.getProductName()).isEqualTo("새 상품명");
-            assertThat(product.getPrice()).isEqualTo(20000L);
+            assertThat(product.getListPrice()).isEqualTo(20000L);
+            assertThat(product.getSellingPrice()).isEqualTo(18000L);
             assertThat(product.getDescription()).isEqualTo("새 설명");
         }
 
@@ -132,16 +151,17 @@ class ProductTest {
         @DisplayName("판매 중단된 상품의 정보도 수정할 수 있다")
         void modifyProduct_whenInactive_succeeds() {
             // given
-            Product product = Product.create("기존 상품명", 10000L, "KRW", "기존 설명");
+            Product product = Product.create("기존 상품명", 10000L, 9000L, "KRW", "기존 설명");
             product.changeStatus(ProductStatus.ACTIVE);
             product.changeStatus(ProductStatus.INACTIVE);
 
             // when
-            product.modify("새 상품명", 20000L, "KRW", "새 설명");
+            product.modify("새 상품명", 20000L, 18000L, "KRW", "새 설명");
 
             // then
             assertThat(product.getProductName()).isEqualTo("새 상품명");
-            assertThat(product.getPrice()).isEqualTo(20000L);
+            assertThat(product.getListPrice()).isEqualTo(20000L);
+            assertThat(product.getSellingPrice()).isEqualTo(18000L);
             assertThat(product.getDescription()).isEqualTo("새 설명");
         }
 
@@ -149,12 +169,23 @@ class ProductTest {
         @DisplayName("판매 종료된 상품은 정보를 수정할 수 없다")
         void modifyProduct_whenDiscontinued_throwsException() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = Product.create("상품명", 10000L, 9000L, "KRW", "설명");
             product.changeStatus(ProductStatus.DISCONTINUED);
 
             // when & then
-            assertThatThrownBy(() -> product.modify("새 상품명", 20000L, "KRW", "새 설명"))
+            assertThatThrownBy(() -> product.modify("새 상품명", 20000L, 18000L, "KRW", "새 설명"))
                     .isInstanceOf(InvalidProductStatusException.class);
+        }
+
+        @Test
+        @DisplayName("수정 시 판매가가 정가보다 크면 예외가 발생한다")
+        void modifyProduct_whenSellingPriceGreaterThanListPrice_throwsException() {
+            // given
+            Product product = Product.create("상품명", 10000L, 9000L, "KRW", "설명");
+
+            // when & then
+            assertThatThrownBy(() -> product.modify("상품명", 10000L, 11000L, "KRW", "설명"))
+                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -166,7 +197,7 @@ class ProductTest {
         @DisplayName("DRAFT 상품을 판매 활성화할 수 있다")
         void changeStatus_fromDraftToActive_succeeds() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
 
             // when
             product.changeStatus(ProductStatus.ACTIVE);
@@ -179,7 +210,7 @@ class ProductTest {
         @DisplayName("DRAFT 상품을 판매 종료 처리할 수 있다")
         void changeStatus_fromDraftToDiscontinued_succeeds() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
 
             // when
             product.changeStatus(ProductStatus.DISCONTINUED);
@@ -192,7 +223,7 @@ class ProductTest {
         @DisplayName("DRAFT 상품을 INACTIVE로 바로 전이할 수 없다")
         void changeStatus_fromDraftToInactive_throwsException() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
 
             // when & then
             assertThatThrownBy(() -> product.changeStatus(ProductStatus.INACTIVE))
@@ -203,7 +234,7 @@ class ProductTest {
         @DisplayName("판매 중인 상품을 판매 중단할 수 있다")
         void changeStatus_fromActiveToInactive_succeeds() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
 
             // when
@@ -217,7 +248,7 @@ class ProductTest {
         @DisplayName("판매 중인 상품을 판매 종료 처리할 수 있다")
         void changeStatus_fromActiveToDiscontinued_succeeds() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
 
             // when
@@ -231,7 +262,7 @@ class ProductTest {
         @DisplayName("판매 중인 상품을 DRAFT로 되돌릴 수 없다")
         void changeStatus_fromActiveToDraft_throwsException() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
 
             // when & then
@@ -243,7 +274,7 @@ class ProductTest {
         @DisplayName("판매 중단된 상품을 재판매할 수 있다")
         void changeStatus_fromInactiveToActive_succeeds() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
             product.changeStatus(ProductStatus.INACTIVE);
 
@@ -258,7 +289,7 @@ class ProductTest {
         @DisplayName("판매 중단된 상품을 판매 종료 처리할 수 있다")
         void changeStatus_fromInactiveToDiscontinued_succeeds() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
             product.changeStatus(ProductStatus.INACTIVE);
 
@@ -273,7 +304,7 @@ class ProductTest {
         @DisplayName("판매 중단된 상품을 DRAFT로 되돌릴 수 없다")
         void changeStatus_fromInactiveToDraft_throwsException() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
             product.changeStatus(ProductStatus.INACTIVE);
 
@@ -286,7 +317,7 @@ class ProductTest {
         @DisplayName("판매 종료된 상품은 다시 판매 활성화할 수 없다")
         void changeStatus_fromDiscontinuedToActive_throwsException() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.DISCONTINUED);
 
             // when & then
@@ -298,7 +329,7 @@ class ProductTest {
         @DisplayName("판매 종료된 상품은 비활성으로도 되돌릴 수 없다")
         void changeStatus_fromDiscontinuedToInactive_throwsException() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.DISCONTINUED);
 
             // when & then
@@ -310,7 +341,7 @@ class ProductTest {
         @DisplayName("판매 종료 상태를 판매 종료로 다시 설정해도 예외가 발생하지 않는다")
         void changeStatus_fromDiscontinuedToDiscontinued_succeeds() {
             // given
-            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.DISCONTINUED);
 
             // when
@@ -318,6 +349,10 @@ class ProductTest {
 
             // then
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DISCONTINUED);
+        }
+
+        private Product newDraftProduct() {
+            return Product.create("상품명", 10000L, 9000L, "KRW", "설명");
         }
     }
 }

--- a/service/product-service/src/test/java/dev/labs/commerce/product/core/product/domain/ProductTest.java
+++ b/service/product-service/src/test/java/dev/labs/commerce/product/core/product/domain/ProductTest.java
@@ -16,8 +16,8 @@ class ProductTest {
     class Create {
 
         @Test
-        @DisplayName("유효한 정보로 상품을 등록하면 판매 비활성 상태로 생성된다")
-        void createProduct_withValidInfo_startsAsInactive() {
+        @DisplayName("유효한 정보로 상품을 등록하면 DRAFT 상태로 생성된다")
+        void createProduct_withValidInfo_startsAsDraft() {
             // given
             String name = "테스트 상품";
             long price = 10000L;
@@ -32,7 +32,7 @@ class ProductTest {
             assertThat(product.getPrice()).isEqualTo(price);
             assertThat(product.getCurrency()).isEqualTo(currency);
             assertThat(product.getDescription()).isEqualTo(description);
-            assertThat(product.getProductStatus()).isEqualTo(ProductStatus.INACTIVE);
+            assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DRAFT);
         }
 
         @Test
@@ -98,8 +98,8 @@ class ProductTest {
     class Modify {
 
         @Test
-        @DisplayName("비활성 상품의 정보를 수정할 수 있다")
-        void modifyProduct_whenInactive_succeeds() {
+        @DisplayName("DRAFT 상품의 정보를 수정할 수 있다")
+        void modifyProduct_whenDraft_succeeds() {
             // given
             Product product = Product.create("기존 상품명", 10000L, "KRW", "기존 설명");
 
@@ -129,6 +129,23 @@ class ProductTest {
         }
 
         @Test
+        @DisplayName("판매 중단된 상품의 정보도 수정할 수 있다")
+        void modifyProduct_whenInactive_succeeds() {
+            // given
+            Product product = Product.create("기존 상품명", 10000L, "KRW", "기존 설명");
+            product.changeStatus(ProductStatus.ACTIVE);
+            product.changeStatus(ProductStatus.INACTIVE);
+
+            // when
+            product.modify("새 상품명", 20000L, "KRW", "새 설명");
+
+            // then
+            assertThat(product.getProductName()).isEqualTo("새 상품명");
+            assertThat(product.getPrice()).isEqualTo(20000L);
+            assertThat(product.getDescription()).isEqualTo("새 설명");
+        }
+
+        @Test
         @DisplayName("판매 종료된 상품은 정보를 수정할 수 없다")
         void modifyProduct_whenDiscontinued_throwsException() {
             // given
@@ -146,8 +163,8 @@ class ProductTest {
     class ChangeStatus {
 
         @Test
-        @DisplayName("비활성 상품을 판매 활성화할 수 있다")
-        void changeStatus_fromInactiveToActive_succeeds() {
+        @DisplayName("DRAFT 상품을 판매 활성화할 수 있다")
+        void changeStatus_fromDraftToActive_succeeds() {
             // given
             Product product = Product.create("상품명", 10000L, "KRW", "설명");
 
@@ -159,7 +176,31 @@ class ProductTest {
         }
 
         @Test
-        @DisplayName("판매 중인 상품을 비활성화할 수 있다")
+        @DisplayName("DRAFT 상품을 판매 종료 처리할 수 있다")
+        void changeStatus_fromDraftToDiscontinued_succeeds() {
+            // given
+            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+
+            // when
+            product.changeStatus(ProductStatus.DISCONTINUED);
+
+            // then
+            assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DISCONTINUED);
+        }
+
+        @Test
+        @DisplayName("DRAFT 상품을 INACTIVE로 바로 전이할 수 없다")
+        void changeStatus_fromDraftToInactive_throwsException() {
+            // given
+            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+
+            // when & then
+            assertThatThrownBy(() -> product.changeStatus(ProductStatus.INACTIVE))
+                    .isInstanceOf(InvalidProductStatusException.class);
+        }
+
+        @Test
+        @DisplayName("판매 중인 상품을 판매 중단할 수 있다")
         void changeStatus_fromActiveToInactive_succeeds() {
             // given
             Product product = Product.create("상품명", 10000L, "KRW", "설명");
@@ -184,6 +225,61 @@ class ProductTest {
 
             // then
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DISCONTINUED);
+        }
+
+        @Test
+        @DisplayName("판매 중인 상품을 DRAFT로 되돌릴 수 없다")
+        void changeStatus_fromActiveToDraft_throwsException() {
+            // given
+            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            product.changeStatus(ProductStatus.ACTIVE);
+
+            // when & then
+            assertThatThrownBy(() -> product.changeStatus(ProductStatus.DRAFT))
+                    .isInstanceOf(InvalidProductStatusException.class);
+        }
+
+        @Test
+        @DisplayName("판매 중단된 상품을 재판매할 수 있다")
+        void changeStatus_fromInactiveToActive_succeeds() {
+            // given
+            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            product.changeStatus(ProductStatus.ACTIVE);
+            product.changeStatus(ProductStatus.INACTIVE);
+
+            // when
+            product.changeStatus(ProductStatus.ACTIVE);
+
+            // then
+            assertThat(product.getProductStatus()).isEqualTo(ProductStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("판매 중단된 상품을 판매 종료 처리할 수 있다")
+        void changeStatus_fromInactiveToDiscontinued_succeeds() {
+            // given
+            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            product.changeStatus(ProductStatus.ACTIVE);
+            product.changeStatus(ProductStatus.INACTIVE);
+
+            // when
+            product.changeStatus(ProductStatus.DISCONTINUED);
+
+            // then
+            assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DISCONTINUED);
+        }
+
+        @Test
+        @DisplayName("판매 중단된 상품을 DRAFT로 되돌릴 수 없다")
+        void changeStatus_fromInactiveToDraft_throwsException() {
+            // given
+            Product product = Product.create("상품명", 10000L, "KRW", "설명");
+            product.changeStatus(ProductStatus.ACTIVE);
+            product.changeStatus(ProductStatus.INACTIVE);
+
+            // when & then
+            assertThatThrownBy(() -> product.changeStatus(ProductStatus.DRAFT))
+                    .isInstanceOf(InvalidProductStatusException.class);
         }
 
         @Test

--- a/service/product-service/src/test/java/dev/labs/commerce/product/core/product/domain/ProductTest.java
+++ b/service/product-service/src/test/java/dev/labs/commerce/product/core/product/domain/ProductTest.java
@@ -6,10 +6,20 @@ import org.junit.jupiter.api.Test;
 
 import dev.labs.commerce.product.core.product.domain.error.InvalidProductStatusException;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ProductTest {
+
+    private static Product newDraftProduct() {
+        return Product.create(
+                "상품명", 10000L, 9000L, "KRW",
+                ProductCategory.FIGURE, null, null, null, "설명"
+        );
+    }
 
     @Nested
     @DisplayName("상품 등록")
@@ -18,95 +28,158 @@ class ProductTest {
         @Test
         @DisplayName("유효한 정보로 상품을 등록하면 DRAFT 상태로 생성된다")
         void createProduct_withValidInfo_startsAsDraft() {
-            // given
-            String name = "테스트 상품";
-            long listPrice = 10000L;
-            long sellingPrice = 9000L;
-            String currency = "KRW";
-            String description = "테스트 상품 설명";
+            Instant saleStart = Instant.now().plus(1, ChronoUnit.DAYS);
+            Instant saleEnd = Instant.now().plus(10, ChronoUnit.DAYS);
 
-            // when
-            Product product = Product.create(name, listPrice, sellingPrice, currency, description);
+            Product product = Product.create(
+                    "테스트 상품", 10000L, 9000L, "KRW",
+                    ProductCategory.PLUSH, saleStart, saleEnd, "https://cdn.example.com/thumb.jpg",
+                    "테스트 상품 설명"
+            );
 
-            // then
-            assertThat(product.getProductName()).isEqualTo(name);
-            assertThat(product.getListPrice()).isEqualTo(listPrice);
-            assertThat(product.getSellingPrice()).isEqualTo(sellingPrice);
-            assertThat(product.getCurrency()).isEqualTo(currency);
-            assertThat(product.getDescription()).isEqualTo(description);
+            assertThat(product.getProductName()).isEqualTo("테스트 상품");
+            assertThat(product.getListPrice()).isEqualTo(10000L);
+            assertThat(product.getSellingPrice()).isEqualTo(9000L);
+            assertThat(product.getCurrency()).isEqualTo("KRW");
+            assertThat(product.getCategory()).isEqualTo(ProductCategory.PLUSH);
+            assertThat(product.getSaleStartAt()).isEqualTo(saleStart);
+            assertThat(product.getSaleEndAt()).isEqualTo(saleEnd);
+            assertThat(product.getThumbnailUrl()).isEqualTo("https://cdn.example.com/thumb.jpg");
+            assertThat(product.getDescription()).isEqualTo("테스트 상품 설명");
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DRAFT);
+        }
+
+        @Test
+        @DisplayName("판매기간/썸네일이 null이어도 등록할 수 있다")
+        void createProduct_withNullOptionalFields_succeeds() {
+            Product product = Product.create(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.ETC, null, null, null, "설명"
+            );
+
+            assertThat(product.getSaleStartAt()).isNull();
+            assertThat(product.getSaleEndAt()).isNull();
+            assertThat(product.getThumbnailUrl()).isNull();
         }
 
         @Test
         @DisplayName("상품명이 없으면 등록할 수 없다")
         void createProduct_withBlankName_throwsException() {
-            // given
-            String blankName = " ";
-
-            // when & then
-            assertThatThrownBy(() -> Product.create(blankName, 10000L, 10000L, "KRW", "설명"))
-                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> Product.create(
+                    " ", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         @DisplayName("정가가 음수이면 등록할 수 없다")
         void createProduct_withNegativeListPrice_throwsException() {
-            assertThatThrownBy(() -> Product.create("상품명", -1L, 0L, "KRW", "설명"))
-                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> Product.create(
+                    "상품명", -1L, 0L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         @DisplayName("판매가가 음수이면 등록할 수 없다")
         void createProduct_withNegativeSellingPrice_throwsException() {
-            assertThatThrownBy(() -> Product.create("상품명", 10000L, -1L, "KRW", "설명"))
-                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> Product.create(
+                    "상품명", 10000L, -1L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         @DisplayName("판매가가 정가보다 크면 등록할 수 없다")
         void createProduct_whenSellingPriceGreaterThanListPrice_throwsException() {
-            assertThatThrownBy(() -> Product.create("상품명", 10000L, 11000L, "KRW", "설명"))
-                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> Product.create(
+                    "상품명", 10000L, 11000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         @DisplayName("판매가가 정가와 같으면 등록할 수 있다")
         void createProduct_whenSellingPriceEqualsListPrice_succeeds() {
-            Product product = Product.create("상품명", 10000L, 10000L, "KRW", "설명");
+            Product product = Product.create(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            );
 
             assertThat(product.getListPrice()).isEqualTo(10000L);
             assertThat(product.getSellingPrice()).isEqualTo(10000L);
         }
 
         @Test
-        @DisplayName("정가와 판매가가 모두 0원인 상품은 등록할 수 있다")
-        void createProduct_withZeroPrices_succeeds() {
-            Product product = Product.create("상품명", 0L, 0L, "KRW", "설명");
+        @DisplayName("카테고리가 null이면 등록할 수 없다")
+        void createProduct_withNullCategory_throwsException() {
+            assertThatThrownBy(() -> Product.create(
+                    "상품명", 10000L, 10000L, "KRW",
+                    null, null, null, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
+        }
 
-            assertThat(product.getListPrice()).isZero();
-            assertThat(product.getSellingPrice()).isZero();
+        @Test
+        @DisplayName("판매종료일이 과거이면 등록할 수 없다")
+        void createProduct_whenSaleEndAtIsInPast_throwsException() {
+            Instant past = Instant.now().minus(1, ChronoUnit.DAYS);
+            assertThatThrownBy(() -> Product.create(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, null, past, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("판매시작일이 판매종료일보다 이후이면 등록할 수 없다")
+        void createProduct_whenSaleStartAtAfterSaleEndAt_throwsException() {
+            Instant start = Instant.now().plus(10, ChronoUnit.DAYS);
+            Instant end = Instant.now().plus(5, ChronoUnit.DAYS);
+            assertThatThrownBy(() -> Product.create(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, start, end, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("판매시작일이 과거여도 등록할 수 있다")
+        void createProduct_whenSaleStartAtIsInPast_succeeds() {
+            Instant pastStart = Instant.now().minus(1, ChronoUnit.DAYS);
+            Instant futureEnd = Instant.now().plus(5, ChronoUnit.DAYS);
+
+            Product product = Product.create(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, pastStart, futureEnd, null, "설명"
+            );
+
+            assertThat(product.getSaleStartAt()).isEqualTo(pastStart);
+        }
+
+        @Test
+        @DisplayName("썸네일 URL 길이가 500을 초과하면 등록할 수 없다")
+        void createProduct_whenThumbnailUrlTooLong_throwsException() {
+            String tooLong = "https://cdn.example.com/" + "a".repeat(500);
+            assertThatThrownBy(() -> Product.create(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, null, null, tooLong, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         @DisplayName("통화 단위가 없으면 등록할 수 없다")
         void createProduct_withBlankCurrency_throwsException() {
-            // given
-            String blankCurrency = " ";
-
-            // when & then
-            assertThatThrownBy(() -> Product.create("상품명", 10000L, 10000L, blankCurrency, "설명"))
-                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> Product.create(
+                    "상품명", 10000L, 10000L, " ",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         @DisplayName("상품 설명이 없으면 등록할 수 없다")
         void createProduct_withBlankDescription_throwsException() {
-            // given
-            String blankDescription = " ";
-
-            // when & then
-            assertThatThrownBy(() -> Product.create("상품명", 10000L, 10000L, "KRW", blankDescription))
-                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> Product.create(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, " "
+            )).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -117,75 +190,59 @@ class ProductTest {
         @Test
         @DisplayName("DRAFT 상품의 정보를 수정할 수 있다")
         void modifyProduct_whenDraft_succeeds() {
-            // given
-            Product product = Product.create("기존 상품명", 10000L, 9000L, "KRW", "기존 설명");
+            Product product = newDraftProduct();
+            Instant newStart = Instant.now().plus(2, ChronoUnit.DAYS);
+            Instant newEnd = Instant.now().plus(20, ChronoUnit.DAYS);
 
-            // when
-            product.modify("새 상품명", 20000L, 18000L, "KRW", "새 설명");
+            product.modify(
+                    "새 상품명", 20000L, 18000L, "KRW",
+                    ProductCategory.MODEL_KIT, newStart, newEnd, "https://cdn.example.com/new.jpg",
+                    "새 설명"
+            );
 
-            // then
             assertThat(product.getProductName()).isEqualTo("새 상품명");
             assertThat(product.getListPrice()).isEqualTo(20000L);
             assertThat(product.getSellingPrice()).isEqualTo(18000L);
-            assertThat(product.getDescription()).isEqualTo("새 설명");
-        }
-
-        @Test
-        @DisplayName("판매 중인 상품의 정보를 수정할 수 있다")
-        void modifyProduct_whenActive_succeeds() {
-            // given
-            Product product = Product.create("기존 상품명", 10000L, 9000L, "KRW", "기존 설명");
-            product.changeStatus(ProductStatus.ACTIVE);
-
-            // when
-            product.modify("새 상품명", 20000L, 18000L, "KRW", "새 설명");
-
-            // then
-            assertThat(product.getProductName()).isEqualTo("새 상품명");
-            assertThat(product.getListPrice()).isEqualTo(20000L);
-            assertThat(product.getSellingPrice()).isEqualTo(18000L);
-            assertThat(product.getDescription()).isEqualTo("새 설명");
-        }
-
-        @Test
-        @DisplayName("판매 중단된 상품의 정보도 수정할 수 있다")
-        void modifyProduct_whenInactive_succeeds() {
-            // given
-            Product product = Product.create("기존 상품명", 10000L, 9000L, "KRW", "기존 설명");
-            product.changeStatus(ProductStatus.ACTIVE);
-            product.changeStatus(ProductStatus.INACTIVE);
-
-            // when
-            product.modify("새 상품명", 20000L, 18000L, "KRW", "새 설명");
-
-            // then
-            assertThat(product.getProductName()).isEqualTo("새 상품명");
-            assertThat(product.getListPrice()).isEqualTo(20000L);
-            assertThat(product.getSellingPrice()).isEqualTo(18000L);
+            assertThat(product.getCategory()).isEqualTo(ProductCategory.MODEL_KIT);
+            assertThat(product.getSaleStartAt()).isEqualTo(newStart);
+            assertThat(product.getSaleEndAt()).isEqualTo(newEnd);
+            assertThat(product.getThumbnailUrl()).isEqualTo("https://cdn.example.com/new.jpg");
             assertThat(product.getDescription()).isEqualTo("새 설명");
         }
 
         @Test
         @DisplayName("판매 종료된 상품은 정보를 수정할 수 없다")
         void modifyProduct_whenDiscontinued_throwsException() {
-            // given
-            Product product = Product.create("상품명", 10000L, 9000L, "KRW", "설명");
+            Product product = newDraftProduct();
             product.changeStatus(ProductStatus.DISCONTINUED);
 
-            // when & then
-            assertThatThrownBy(() -> product.modify("새 상품명", 20000L, 18000L, "KRW", "새 설명"))
-                    .isInstanceOf(InvalidProductStatusException.class);
+            assertThatThrownBy(() -> product.modify(
+                    "새 상품명", 20000L, 18000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "새 설명"
+            )).isInstanceOf(InvalidProductStatusException.class);
         }
 
         @Test
         @DisplayName("수정 시 판매가가 정가보다 크면 예외가 발생한다")
         void modifyProduct_whenSellingPriceGreaterThanListPrice_throwsException() {
-            // given
-            Product product = Product.create("상품명", 10000L, 9000L, "KRW", "설명");
+            Product product = newDraftProduct();
 
-            // when & then
-            assertThatThrownBy(() -> product.modify("상품명", 10000L, 11000L, "KRW", "설명"))
-                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> product.modify(
+                    "상품명", 10000L, 11000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("수정 시 판매종료일이 과거이면 예외가 발생한다")
+        void modifyProduct_whenSaleEndAtIsInPast_throwsException() {
+            Product product = newDraftProduct();
+            Instant past = Instant.now().minus(1, ChronoUnit.DAYS);
+
+            assertThatThrownBy(() -> product.modify(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, null, past, null, "설명"
+            )).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -196,36 +253,23 @@ class ProductTest {
         @Test
         @DisplayName("DRAFT 상품을 판매 활성화할 수 있다")
         void changeStatus_fromDraftToActive_succeeds() {
-            // given
             Product product = newDraftProduct();
-
-            // when
             product.changeStatus(ProductStatus.ACTIVE);
-
-            // then
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.ACTIVE);
         }
 
         @Test
         @DisplayName("DRAFT 상품을 판매 종료 처리할 수 있다")
         void changeStatus_fromDraftToDiscontinued_succeeds() {
-            // given
             Product product = newDraftProduct();
-
-            // when
             product.changeStatus(ProductStatus.DISCONTINUED);
-
-            // then
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DISCONTINUED);
         }
 
         @Test
         @DisplayName("DRAFT 상품을 INACTIVE로 바로 전이할 수 없다")
         void changeStatus_fromDraftToInactive_throwsException() {
-            // given
             Product product = newDraftProduct();
-
-            // when & then
             assertThatThrownBy(() -> product.changeStatus(ProductStatus.INACTIVE))
                     .isInstanceOf(InvalidProductStatusException.class);
         }
@@ -233,39 +277,26 @@ class ProductTest {
         @Test
         @DisplayName("판매 중인 상품을 판매 중단할 수 있다")
         void changeStatus_fromActiveToInactive_succeeds() {
-            // given
             Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
-
-            // when
             product.changeStatus(ProductStatus.INACTIVE);
-
-            // then
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.INACTIVE);
         }
 
         @Test
         @DisplayName("판매 중인 상품을 판매 종료 처리할 수 있다")
         void changeStatus_fromActiveToDiscontinued_succeeds() {
-            // given
             Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
-
-            // when
             product.changeStatus(ProductStatus.DISCONTINUED);
-
-            // then
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DISCONTINUED);
         }
 
         @Test
         @DisplayName("판매 중인 상품을 DRAFT로 되돌릴 수 없다")
         void changeStatus_fromActiveToDraft_throwsException() {
-            // given
             Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
-
-            // when & then
             assertThatThrownBy(() -> product.changeStatus(ProductStatus.DRAFT))
                     .isInstanceOf(InvalidProductStatusException.class);
         }
@@ -273,42 +304,29 @@ class ProductTest {
         @Test
         @DisplayName("판매 중단된 상품을 재판매할 수 있다")
         void changeStatus_fromInactiveToActive_succeeds() {
-            // given
             Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
             product.changeStatus(ProductStatus.INACTIVE);
-
-            // when
             product.changeStatus(ProductStatus.ACTIVE);
-
-            // then
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.ACTIVE);
         }
 
         @Test
         @DisplayName("판매 중단된 상품을 판매 종료 처리할 수 있다")
         void changeStatus_fromInactiveToDiscontinued_succeeds() {
-            // given
             Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
             product.changeStatus(ProductStatus.INACTIVE);
-
-            // when
             product.changeStatus(ProductStatus.DISCONTINUED);
-
-            // then
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DISCONTINUED);
         }
 
         @Test
         @DisplayName("판매 중단된 상품을 DRAFT로 되돌릴 수 없다")
         void changeStatus_fromInactiveToDraft_throwsException() {
-            // given
             Product product = newDraftProduct();
             product.changeStatus(ProductStatus.ACTIVE);
             product.changeStatus(ProductStatus.INACTIVE);
-
-            // when & then
             assertThatThrownBy(() -> product.changeStatus(ProductStatus.DRAFT))
                     .isInstanceOf(InvalidProductStatusException.class);
         }
@@ -316,11 +334,8 @@ class ProductTest {
         @Test
         @DisplayName("판매 종료된 상품은 다시 판매 활성화할 수 없다")
         void changeStatus_fromDiscontinuedToActive_throwsException() {
-            // given
             Product product = newDraftProduct();
             product.changeStatus(ProductStatus.DISCONTINUED);
-
-            // when & then
             assertThatThrownBy(() -> product.changeStatus(ProductStatus.ACTIVE))
                     .isInstanceOf(InvalidProductStatusException.class);
         }
@@ -328,11 +343,8 @@ class ProductTest {
         @Test
         @DisplayName("판매 종료된 상품은 비활성으로도 되돌릴 수 없다")
         void changeStatus_fromDiscontinuedToInactive_throwsException() {
-            // given
             Product product = newDraftProduct();
             product.changeStatus(ProductStatus.DISCONTINUED);
-
-            // when & then
             assertThatThrownBy(() -> product.changeStatus(ProductStatus.INACTIVE))
                     .isInstanceOf(InvalidProductStatusException.class);
         }
@@ -340,19 +352,58 @@ class ProductTest {
         @Test
         @DisplayName("판매 종료 상태를 판매 종료로 다시 설정해도 예외가 발생하지 않는다")
         void changeStatus_fromDiscontinuedToDiscontinued_succeeds() {
-            // given
             Product product = newDraftProduct();
             product.changeStatus(ProductStatus.DISCONTINUED);
-
-            // when
             product.changeStatus(ProductStatus.DISCONTINUED);
-
-            // then
             assertThat(product.getProductStatus()).isEqualTo(ProductStatus.DISCONTINUED);
         }
+    }
 
-        private Product newDraftProduct() {
-            return Product.create("상품명", 10000L, 9000L, "KRW", "설명");
+    @Nested
+    @DisplayName("판매 스케줄 조회")
+    class SaleSchedule {
+
+        @Test
+        @DisplayName("INACTIVE + 판매시작일이 미래면 isScheduled는 true")
+        void isScheduled_whenInactiveAndStartInFuture_returnsTrue() {
+            Product product = Product.create(
+                    "상품명", 10000L, 9000L, "KRW",
+                    ProductCategory.FIGURE,
+                    Instant.now().plus(1, ChronoUnit.DAYS),
+                    Instant.now().plus(10, ChronoUnit.DAYS),
+                    null, "설명"
+            );
+            product.changeStatus(ProductStatus.ACTIVE);
+            product.changeStatus(ProductStatus.INACTIVE);
+
+            assertThat(product.isScheduled()).isTrue();
+            assertThat(product.isSaleExpired()).isFalse();
+        }
+
+        @Test
+        @DisplayName("ACTIVE 상태에서는 isScheduled/isSaleExpired 모두 false")
+        void isScheduledAndExpired_whenActive_returnsFalse() {
+            Product product = Product.create(
+                    "상품명", 10000L, 9000L, "KRW",
+                    ProductCategory.FIGURE,
+                    Instant.now().plus(1, ChronoUnit.DAYS),
+                    Instant.now().plus(10, ChronoUnit.DAYS),
+                    null, "설명"
+            );
+            product.changeStatus(ProductStatus.ACTIVE);
+
+            assertThat(product.isScheduled()).isFalse();
+            assertThat(product.isSaleExpired()).isFalse();
+        }
+
+        @Test
+        @DisplayName("판매시작일이 null이면 isScheduled는 false")
+        void isScheduled_whenSaleStartAtIsNull_returnsFalse() {
+            Product product = newDraftProduct();
+            product.changeStatus(ProductStatus.ACTIVE);
+            product.changeStatus(ProductStatus.INACTIVE);
+
+            assertThat(product.isScheduled()).isFalse();
         }
     }
 }


### PR DESCRIPTION
## 변경사항

- Product에 `listPrice/sellingPrice`, `category`(enum), `saleStartAt/saleEndAt`, `thumbnailUrl` 필드를 추가
- DRAFT 상태 도입
    - 최초 등록 상태로 특정조건(판매기간 도래, 관리자 활성화)을 충족해야 판매가능 상태로 변경된다.
    - 기존에는 초기 상태가 INACTIVE 였으나, DRAFT 추가 후 INACTIVE는 일시정지 상태를 표현

## 관련 이슈

Closes #38