### PR TITLE
상품 생명주기 도메인 이벤트 발행 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ dev.labs.commerce.{service}
 | `order.expired`            | order-service     | inventory-service |
 | `order.paid`               | order-service     | inventory-service |
 | `product.registered`       | product-service   | inventory-service |
+| `product.activated`        | product-service   | -                 |
+| `product.deactivated`      | product-service   | -                 |
+| `product.discontinued`     | product-service   | -                 |
+| `product.modified`         | product-service   | -                 |
 | `stock.reservation.failed` | inventory-service | order-service     |
 | `payment.initialized`      | payment-service   | order-service     |
 | `payment.approved`         | payment-service   | order-service     |

--- a/service/product-service/README.md
+++ b/service/product-service/README.md
@@ -9,12 +9,15 @@
 
 ## 2. 도메인 용어 사전 (Ubiquitous Language)
 
-| 용어                        | 정의                                       | 비고                                   |
-|:--------------------------|:-----------------------------------------|:-------------------------------------|
-| **Product (상품)**          | 판매의 최소 단위. 이름, 가격, 통화, 설명 정보를 가짐.        |                                      |
-| **ProductStatus (상품 상태)** | 상품의 노출 및 판매 가능 여부를 결정하는 상태.              | `DRAFT`, `INACTIVE`, `ACTIVE`, `DISCONTINUED` |
-| **Price (가격)**            | 상품의 판매 금액. 0원 이상이어야 함.                   | 음수 불가                                |
-| **Discontinued (판매 종료)** | 더 이상 판매하지 않으며, 정보 수정 및 재활성화가 불가능한 최종 상태. |                                      |
+| 용어                             | 정의                                                         | 비고                                                                                  |
+|:-------------------------------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------|
+| **Product (상품)**               | 판매의 최소 단위. 이름, 정가·판매가, 통화, 카테고리, 판매 기간, 썸네일, 설명을 속성으로 가짐.  |                                                                                     |
+| **ProductStatus (상품 상태)**      | 상품의 노출 및 판매 가능 여부를 결정하는 상태.                                | `DRAFT`, `INACTIVE`, `ACTIVE`, `DISCONTINUED`                                       |
+| **ListPrice (정가)**             | 상품의 공식 소비자 가격. 0원 이상이어야 함.                                 | 음수 불가                                                                               |
+| **SellingPrice (판매가)**         | 실제 결제되는 가격. 0원 이상이며 `listPrice` 이하여야 함.                    | 할인 적용 결과가 이 값                                                                       |
+| **ProductCategory (카테고리)**     | 상품 분류.                                                     | `FIGURE`, `PLUSH`, `MODEL_KIT`, `TRADING_CARD`, `BOARD_GAME`, `DIECAST`, `PUZZLE`, `ACCESSORY`, `ETC` |
+| **SalePeriod (판매 기간)**         | 판매 시작/종료 시각(`saleStartAt`, `saleEndAt`). 선택 필드.             | 종료일은 과거일 수 없고, 시작일은 종료일보다 앞서야 함                                                     |
+| **Discontinued (판매 종료)**       | 더 이상 판매하지 않으며, 정보 수정 및 재활성화가 불가능한 최종 상태.                    |                                                                                     |
 
 ---
 
@@ -22,8 +25,10 @@
 
 ### 3.1 데이터 정합성 제약
 
-- **필수 정보**: 상품 이름, 가격, 통화(Currency), 설명은 등록 시 반드시 입력되어야 합니다. (`null` 또는 공백 불가)
-- **가격 제약**: 모든 상품의 가격(`price`)은 **0원 이상**이어야 합니다. (0원 포함, 음수 불가)
+- **필수 정보**: 상품 이름, 정가(`listPrice`), 판매가(`sellingPrice`), 통화(`currency`), 카테고리(`category`), 설명(`description`)은 등록 시 반드시 입력되어야 합니다. (`null` 또는 공백 불가)
+- **가격 제약**: `listPrice`와 `sellingPrice`는 각각 **0원 이상**이어야 하며, `sellingPrice`는 `listPrice`보다 클 수 없습니다.
+- **판매 기간 제약**: `saleEndAt`은 과거일 수 없고, `saleStartAt`이 지정된 경우 반드시 `saleEndAt`보다 앞서야 합니다. (둘 다 선택 필드)
+- **썸네일 URL**: `thumbnailUrl`은 선택 필드이며, 최대 500자까지 허용합니다.
 
 ### 3.2 상태 기반 수정 제한
 
@@ -61,18 +66,91 @@ stateDiagram-v2
 
 ### 상품 등록 (Create)
 
-- 입력: 이름, 가격, 통화, 설명
-- 결과: `DRAFT` 상태의 상품 생성
-- 검증: 모든 필드 필수 입력, 가격 >= 0
+- 입력: 이름, 정가, 판매가, 통화, 카테고리, 판매 시작/종료(선택), 썸네일 URL(선택), 설명
+- 결과: `DRAFT` 상태의 상품 생성 → `product.registered` 이벤트 발행
+- 검증: 필수 필드 입력, 정가/판매가 >= 0, 판매가 <= 정가, 판매 기간 유효성
 
 ### 상품 정보 수정 (Modify)
 
-- 대상: 이름, 가격, 통화, 설명
+- 대상: 이름, 정가, 판매가, 통화, 카테고리, 판매 시작/종료, 썸네일 URL, 설명
 - 조건: 현재 상태가 `DISCONTINUED`가 아닐 것
-- 결과: 상품 메타데이터 업데이트
+- 결과: 변경된 필드만 집합으로 반환. 현재 상태가 `ACTIVE` 또는 `INACTIVE`이고 변경 필드가 하나라도 있을 때 `product.modified` 이벤트 발행
+- 참고: `DRAFT` 상태의 수정은 외부에 노출된 적이 없으므로 이벤트를 발행하지 않음
 
 ### 상품 상태 변경 (Change Status)
 
 - 입력: 변경할 목표 상태 (`ProductStatus`)
 - 조건: 허용된 전이 규칙(`ProductStatus.canTransitionTo`)을 따라야 함. 현재 상태가 `DISCONTINUED`이면 다른 상태로 전이할 수 없고, `DRAFT`에서는 `INACTIVE`로 직접 전이할 수 없음
-- 결과: 상태 값 업데이트
+- 결과: 상태 값 업데이트 후 전이 결과에 따라 이벤트 발행 (아래 §6 참조)
+
+---
+
+## 6. 발행 이벤트 (Published Events)
+
+모든 이벤트는 트랜잭션 커밋 이후(`TransactionSynchronization#afterCommit`)에 발행되며, 파티션 키는 `productId`다.
+
+| Topic                  | 발행 시점                                       | 페이로드                                 |
+|------------------------|---------------------------------------------|--------------------------------------|
+| `product.registered`   | 상품 등록(`DRAFT` 생성) 직후                        | `productId`                          |
+| `product.activated`    | 상태가 `ACTIVE`로 전이된 시점 (`DRAFT→ACTIVE`, `INACTIVE→ACTIVE`) | 상품 전체 스냅샷 (카탈로그 노출용)                 |
+| `product.deactivated`  | 상태가 `INACTIVE`로 전이된 시점 (`ACTIVE→INACTIVE`)  | `productId`                          |
+| `product.discontinued` | `ACTIVE` 또는 `INACTIVE`에서 `DISCONTINUED`로 전이된 시점 | `productId`                          |
+| `product.modified`     | `ACTIVE`/`INACTIVE` 상태 상품의 필드가 실제로 변경된 경우   | 변경 후 상품 전체 스냅샷                       |
+
+**발행되지 않는 경우:**
+
+- `DRAFT → DISCONTINUED`: 공개된 적 없는 상품의 폐기이므로 `product.discontinued`를 발행하지 않음
+- 동일 상태로의 전이(`ACTIVE → ACTIVE` 등): 상태가 실제로 바뀌지 않았으므로 미발행
+- `DRAFT` 상태 상품의 정보 수정: 외부에 노출된 적이 없어 `product.modified` 미발행
+- `ModifyProduct` 호출 시 실제 변경된 필드가 없는 경우: `product.modified` 미발행
+
+### 상태 전이 및 이벤트 발행 시퀀스
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant PS as product-service
+    participant DB as PostgreSQL
+    participant K as Kafka
+
+    C ->> PS: POST /api/v1/products
+    activate PS
+    PS ->> DB: insert product (DRAFT)
+    PS -->> C: 201 Created
+    PS ->> K: product.registered (afterCommit)
+    deactivate PS
+
+    C ->> PS: PATCH /products/{id}/status {ACTIVE}
+    activate PS
+    PS ->> DB: update status (DRAFT → ACTIVE)
+    PS -->> C: 200 OK
+    PS ->> K: product.activated (afterCommit)
+    deactivate PS
+
+    C ->> PS: PUT /products/{id}
+    activate PS
+    PS ->> PS: Product.modify() → changedFields
+    alt changedFields ≠ ∅ && status ∈ {ACTIVE, INACTIVE}
+        PS ->> DB: update product
+        PS -->> C: 200 OK
+        PS ->> K: product.modified (afterCommit)
+    else 변경 없음 또는 DRAFT 상태
+        PS ->> DB: update product
+        PS -->> C: 200 OK
+    end
+    deactivate PS
+
+    C ->> PS: PATCH /products/{id}/status {INACTIVE}
+    activate PS
+    PS ->> DB: update status (ACTIVE → INACTIVE)
+    PS -->> C: 200 OK
+    PS ->> K: product.deactivated (afterCommit)
+    deactivate PS
+
+    C ->> PS: PATCH /products/{id}/status {DISCONTINUED}
+    activate PS
+    PS ->> DB: update status (INACTIVE → DISCONTINUED)
+    PS -->> C: 200 OK
+    PS ->> K: product.discontinued (afterCommit)
+    deactivate PS
+```

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductActivatedEvent.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductActivatedEvent.java
@@ -1,0 +1,29 @@
+package dev.labs.commerce.product.core.product.application.event;
+
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record ProductActivatedEvent(
+        Long productId,
+        String productName,
+        Long listPrice,
+        Long sellingPrice,
+        String currency,
+        ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        String thumbnailUrl,
+        String description
+) {
+    public ProductActivatedEvent {
+        Objects.requireNonNull(productId, "productId must not be null");
+        Objects.requireNonNull(productName, "productName must not be null");
+        Objects.requireNonNull(listPrice, "listPrice must not be null");
+        Objects.requireNonNull(sellingPrice, "sellingPrice must not be null");
+        Objects.requireNonNull(currency, "currency must not be null");
+        Objects.requireNonNull(category, "category must not be null");
+        Objects.requireNonNull(description, "description must not be null");
+    }
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductDeactivatedEvent.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductDeactivatedEvent.java
@@ -1,0 +1,9 @@
+package dev.labs.commerce.product.core.product.application.event;
+
+import java.util.Objects;
+
+public record ProductDeactivatedEvent(Long productId) {
+    public ProductDeactivatedEvent {
+        Objects.requireNonNull(productId, "productId must not be null");
+    }
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductDiscontinuedEvent.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductDiscontinuedEvent.java
@@ -1,0 +1,9 @@
+package dev.labs.commerce.product.core.product.application.event;
+
+import java.util.Objects;
+
+public record ProductDiscontinuedEvent(Long productId) {
+    public ProductDiscontinuedEvent {
+        Objects.requireNonNull(productId, "productId must not be null");
+    }
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductEventPublisher.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductEventPublisher.java
@@ -4,4 +4,12 @@ public interface ProductEventPublisher {
 
     void publishProductRegistered(ProductRegisteredEvent event);
 
+    void publishProductActivated(ProductActivatedEvent event);
+
+    void publishProductDeactivated(ProductDeactivatedEvent event);
+
+    void publishProductDiscontinued(ProductDiscontinuedEvent event);
+
+    void publishProductModified(ProductModifiedEvent event);
+
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductModifiedEvent.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/event/ProductModifiedEvent.java
@@ -1,0 +1,29 @@
+package dev.labs.commerce.product.core.product.application.event;
+
+import dev.labs.commerce.product.core.product.domain.ProductCategory;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record ProductModifiedEvent(
+        Long productId,
+        String productName,
+        Long listPrice,
+        Long sellingPrice,
+        String currency,
+        ProductCategory category,
+        Instant saleStartAt,
+        Instant saleEndAt,
+        String thumbnailUrl,
+        String description
+) {
+    public ProductModifiedEvent {
+        Objects.requireNonNull(productId, "productId must not be null");
+        Objects.requireNonNull(productName, "productName must not be null");
+        Objects.requireNonNull(listPrice, "listPrice must not be null");
+        Objects.requireNonNull(sellingPrice, "sellingPrice must not be null");
+        Objects.requireNonNull(currency, "currency must not be null");
+        Objects.requireNonNull(category, "category must not be null");
+        Objects.requireNonNull(description, "description must not be null");
+    }
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ChangeProductStatusUseCase.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ChangeProductStatusUseCase.java
@@ -1,9 +1,14 @@
 package dev.labs.commerce.product.core.product.application.usecase;
 
+import dev.labs.commerce.product.core.product.application.event.ProductActivatedEvent;
+import dev.labs.commerce.product.core.product.application.event.ProductDeactivatedEvent;
+import dev.labs.commerce.product.core.product.application.event.ProductDiscontinuedEvent;
+import dev.labs.commerce.product.core.product.application.event.ProductEventPublisher;
 import dev.labs.commerce.product.core.product.application.usecase.dto.ChangeProductStatusCommand;
 import dev.labs.commerce.product.core.product.application.usecase.dto.ChangeProductStatusResult;
 import dev.labs.commerce.product.core.product.domain.Product;
 import dev.labs.commerce.product.core.product.domain.ProductRepository;
+import dev.labs.commerce.product.core.product.domain.ProductStatus;
 import dev.labs.commerce.product.core.product.domain.error.ProductErrorCode;
 import dev.labs.commerce.product.core.product.domain.error.ProductNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -15,15 +20,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChangeProductStatusUseCase {
 
     private final ProductRepository productRepository;
+    private final ProductEventPublisher productEventPublisher;
 
     @Transactional
     public ChangeProductStatusResult execute(ChangeProductStatusCommand command) {
         Product product = productRepository.findById(command.productId())
                 .orElseThrow(() -> new ProductNotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND, "Product not found: " + command.productId()));
 
+        ProductStatus previousStatus = product.getProductStatus();
+
         product.changeStatus(command.status());
 
         Product updatedProduct = productRepository.save(product);
+
+        publishStatusTransitionEvent(previousStatus, updatedProduct);
 
         return new ChangeProductStatusResult(
                 updatedProduct.getProductId(),
@@ -40,5 +50,38 @@ public class ChangeProductStatusUseCase {
                 updatedProduct.getCreatedAt(),
                 updatedProduct.getUpdatedAt()
         );
+    }
+
+    private void publishStatusTransitionEvent(ProductStatus previousStatus, Product product) {
+        ProductStatus newStatus = product.getProductStatus();
+        if (previousStatus == newStatus) {
+            return;
+        }
+        switch (newStatus) {
+            case ACTIVE -> productEventPublisher.publishProductActivated(new ProductActivatedEvent(
+                    product.getProductId(),
+                    product.getProductName(),
+                    product.getListPrice(),
+                    product.getSellingPrice(),
+                    product.getCurrency(),
+                    product.getCategory(),
+                    product.getSaleStartAt(),
+                    product.getSaleEndAt(),
+                    product.getThumbnailUrl(),
+                    product.getDescription()
+            ));
+            case INACTIVE -> productEventPublisher.publishProductDeactivated(
+                    new ProductDeactivatedEvent(product.getProductId())
+            );
+            case DISCONTINUED -> {
+                // 한 번도 공개된 적 없는(DRAFT) 상품의 폐기는 외부에 알리지 않는다
+                if (previousStatus == ProductStatus.ACTIVE || previousStatus == ProductStatus.INACTIVE) {
+                    productEventPublisher.publishProductDiscontinued(
+                            new ProductDiscontinuedEvent(product.getProductId())
+                    );
+                }
+            }
+            case DRAFT -> { /* 전이 규칙상 도달 불가 */ }
+        }
     }
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ModifyProductUseCase.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ModifyProductUseCase.java
@@ -1,27 +1,33 @@
 package dev.labs.commerce.product.core.product.application.usecase;
 
+import dev.labs.commerce.product.core.product.application.event.ProductEventPublisher;
+import dev.labs.commerce.product.core.product.application.event.ProductModifiedEvent;
 import dev.labs.commerce.product.core.product.application.usecase.dto.ModifyProductCommand;
 import dev.labs.commerce.product.core.product.application.usecase.dto.ModifyProductResult;
 import dev.labs.commerce.product.core.product.domain.Product;
 import dev.labs.commerce.product.core.product.domain.ProductRepository;
+import dev.labs.commerce.product.core.product.domain.ProductStatus;
 import dev.labs.commerce.product.core.product.domain.error.ProductErrorCode;
 import dev.labs.commerce.product.core.product.domain.error.ProductNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 public class ModifyProductUseCase {
 
     private final ProductRepository productRepository;
+    private final ProductEventPublisher productEventPublisher;
 
     @Transactional
     public ModifyProductResult execute(ModifyProductCommand command) {
         Product product = productRepository.findById(command.productId())
                 .orElseThrow(() -> new ProductNotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND, "Product not found: " + command.productId()));
 
-        product.modify(
+        Set<String> changedFields = product.modify(
                 command.productName(),
                 command.listPrice(),
                 command.sellingPrice(),
@@ -34,6 +40,21 @@ public class ModifyProductUseCase {
         );
 
         Product updatedProduct = productRepository.save(product);
+
+        if (!changedFields.isEmpty() && isPubliclyVisible(updatedProduct.getProductStatus())) {
+            productEventPublisher.publishProductModified(new ProductModifiedEvent(
+                    updatedProduct.getProductId(),
+                    updatedProduct.getProductName(),
+                    updatedProduct.getListPrice(),
+                    updatedProduct.getSellingPrice(),
+                    updatedProduct.getCurrency(),
+                    updatedProduct.getCategory(),
+                    updatedProduct.getSaleStartAt(),
+                    updatedProduct.getSaleEndAt(),
+                    updatedProduct.getThumbnailUrl(),
+                    updatedProduct.getDescription()
+            ));
+        }
 
         return new ModifyProductResult(
                 updatedProduct.getProductId(),
@@ -50,5 +71,9 @@ public class ModifyProductUseCase {
                 updatedProduct.getCreatedAt(),
                 updatedProduct.getUpdatedAt()
         );
+    }
+
+    private static boolean isPubliclyVisible(ProductStatus status) {
+        return status == ProductStatus.ACTIVE || status == ProductStatus.INACTIVE;
     }
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/Product.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/Product.java
@@ -10,6 +10,9 @@ import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
 import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
 
 @Entity
 @Table(
@@ -96,7 +99,7 @@ public class Product extends BaseEntity {
         return p;
     }
 
-    public void modify(
+    public Set<String> modify(
             String name,
             long listPrice,
             long sellingPrice,
@@ -115,15 +118,44 @@ public class Product extends BaseEntity {
         validateSalePeriod(saleStartAt, saleEndAt);
         validateThumbnailUrl(thumbnailUrl);
 
-        this.productName = name;
-        this.listPrice = listPrice;
-        this.sellingPrice = sellingPrice;
-        this.currency = currency;
-        this.category = category;
-        this.saleStartAt = saleStartAt;
-        this.saleEndAt = saleEndAt;
-        this.thumbnailUrl = thumbnailUrl;
-        this.description = description;
+        Set<String> changedFields = new LinkedHashSet<>();
+        if (!Objects.equals(this.productName, name)) {
+            changedFields.add("productName");
+            this.productName = name;
+        }
+        if (!Objects.equals(this.listPrice, listPrice)) {
+            changedFields.add("listPrice");
+            this.listPrice = listPrice;
+        }
+        if (!Objects.equals(this.sellingPrice, sellingPrice)) {
+            changedFields.add("sellingPrice");
+            this.sellingPrice = sellingPrice;
+        }
+        if (!Objects.equals(this.currency, currency)) {
+            changedFields.add("currency");
+            this.currency = currency;
+        }
+        if (this.category != category) {
+            changedFields.add("category");
+            this.category = category;
+        }
+        if (!Objects.equals(this.saleStartAt, saleStartAt)) {
+            changedFields.add("saleStartAt");
+            this.saleStartAt = saleStartAt;
+        }
+        if (!Objects.equals(this.saleEndAt, saleEndAt)) {
+            changedFields.add("saleEndAt");
+            this.saleEndAt = saleEndAt;
+        }
+        if (!Objects.equals(this.thumbnailUrl, thumbnailUrl)) {
+            changedFields.add("thumbnailUrl");
+            this.thumbnailUrl = thumbnailUrl;
+        }
+        if (!Objects.equals(this.description, description)) {
+            changedFields.add("description");
+            this.description = description;
+        }
+        return changedFields;
     }
 
     public void changeStatus(ProductStatus newStatus) {

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/infra/messaging/KafkaProductEventPublisher.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/infra/messaging/KafkaProductEventPublisher.java
@@ -2,7 +2,11 @@ package dev.labs.commerce.product.core.product.infra.messaging;
 
 import dev.labs.commerce.common.event.EventEnvelope;
 import dev.labs.commerce.common.event.EventPublisher;
+import dev.labs.commerce.product.core.product.application.event.ProductActivatedEvent;
+import dev.labs.commerce.product.core.product.application.event.ProductDeactivatedEvent;
+import dev.labs.commerce.product.core.product.application.event.ProductDiscontinuedEvent;
 import dev.labs.commerce.product.core.product.application.event.ProductEventPublisher;
+import dev.labs.commerce.product.core.product.application.event.ProductModifiedEvent;
 import dev.labs.commerce.product.core.product.application.event.ProductRegisteredEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,19 +18,48 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class KafkaProductEventPublisher implements ProductEventPublisher {
 
     private static final String PRODUCT_REGISTERED_BINDING = "product-registered-out-0";
+    private static final String PRODUCT_ACTIVATED_BINDING = "product-activated-out-0";
+    private static final String PRODUCT_DEACTIVATED_BINDING = "product-deactivated-out-0";
+    private static final String PRODUCT_DISCONTINUED_BINDING = "product-discontinued-out-0";
+    private static final String PRODUCT_MODIFIED_BINDING = "product-modified-out-0";
 
     private final EventPublisher eventPublisher;
 
     @Override
     public void publishProductRegistered(ProductRegisteredEvent event) {
+        publishAfterCommit(PRODUCT_REGISTERED_BINDING, event.productId(),
+                EventEnvelope.of(event, ProductRegisteredEvent.class));
+    }
+
+    @Override
+    public void publishProductActivated(ProductActivatedEvent event) {
+        publishAfterCommit(PRODUCT_ACTIVATED_BINDING, event.productId(),
+                EventEnvelope.of(event, ProductActivatedEvent.class));
+    }
+
+    @Override
+    public void publishProductDeactivated(ProductDeactivatedEvent event) {
+        publishAfterCommit(PRODUCT_DEACTIVATED_BINDING, event.productId(),
+                EventEnvelope.of(event, ProductDeactivatedEvent.class));
+    }
+
+    @Override
+    public void publishProductDiscontinued(ProductDiscontinuedEvent event) {
+        publishAfterCommit(PRODUCT_DISCONTINUED_BINDING, event.productId(),
+                EventEnvelope.of(event, ProductDiscontinuedEvent.class));
+    }
+
+    @Override
+    public void publishProductModified(ProductModifiedEvent event) {
+        publishAfterCommit(PRODUCT_MODIFIED_BINDING, event.productId(),
+                EventEnvelope.of(event, ProductModifiedEvent.class));
+    }
+
+    private void publishAfterCommit(String binding, Long productId, EventEnvelope<?> envelope) {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                eventPublisher.publish(
-                        PRODUCT_REGISTERED_BINDING,
-                        event.productId().toString(),
-                        EventEnvelope.of(event, ProductRegisteredEvent.class)
-                );
+                eventPublisher.publish(binding, productId.toString(), envelope);
             }
         });
     }

--- a/service/product-service/src/main/resources/application.yml
+++ b/service/product-service/src/main/resources/application.yml
@@ -29,6 +29,18 @@ spring:
         product-registered-out-0:
           destination: product.registered
           content-type: application/json
+        product-activated-out-0:
+          destination: product.activated
+          content-type: application/json
+        product-deactivated-out-0:
+          destination: product.deactivated
+          content-type: application/json
+        product-discontinued-out-0:
+          destination: product.discontinued
+          content-type: application/json
+        product-modified-out-0:
+          destination: product.modified
+          content-type: application/json
 
 management:
   tracing:

--- a/service/product-service/src/test/java/dev/labs/commerce/product/core/product/domain/ProductTest.java
+++ b/service/product-service/src/test/java/dev/labs/commerce/product/core/product/domain/ProductTest.java
@@ -8,6 +8,7 @@ import dev.labs.commerce.product.core.product.domain.error.InvalidProductStatusE
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -243,6 +244,75 @@ class ProductTest {
                     "상품명", 10000L, 10000L, "KRW",
                     ProductCategory.FIGURE, null, past, null, "설명"
             )).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("모든 필드를 새 값으로 수정하면 변경된 필드 이름이 모두 반환된다")
+        void modifyProduct_whenAllFieldsChanged_returnsAllFieldNames() {
+            Product product = newDraftProduct();
+            Instant newStart = Instant.now().plus(2, ChronoUnit.DAYS);
+            Instant newEnd = Instant.now().plus(20, ChronoUnit.DAYS);
+
+            Set<String> changedFields = product.modify(
+                    "새 상품명", 20000L, 18000L, "USD",
+                    ProductCategory.MODEL_KIT, newStart, newEnd, "https://cdn.example.com/new.jpg",
+                    "새 설명"
+            );
+
+            assertThat(changedFields).containsExactlyInAnyOrder(
+                    "productName", "listPrice", "sellingPrice", "currency",
+                    "category", "saleStartAt", "saleEndAt", "thumbnailUrl", "description"
+            );
+        }
+
+        @Test
+        @DisplayName("동일한 값으로 수정하면 변경 필드셋이 비어있다")
+        void modifyProduct_whenNoFieldChanged_returnsEmptySet() {
+            Product product = Product.create(
+                    "상품명", 10000L, 9000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            );
+
+            Set<String> changedFields = product.modify(
+                    "상품명", 10000L, 9000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            );
+
+            assertThat(changedFields).isEmpty();
+        }
+
+        @Test
+        @DisplayName("일부 필드만 변경되면 해당 필드 이름만 반환된다")
+        void modifyProduct_whenSomeFieldsChanged_returnsOnlyChangedFieldNames() {
+            Product product = Product.create(
+                    "상품명", 10000L, 9000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            );
+
+            Set<String> changedFields = product.modify(
+                    "새 상품명", 10000L, 8000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            );
+
+            assertThat(changedFields).containsExactlyInAnyOrder("productName", "sellingPrice");
+        }
+
+        @Test
+        @DisplayName("nullable 필드를 null에서 값으로 바꾸면 변경으로 감지된다")
+        void modifyProduct_whenNullableFieldChangesFromNullToValue_isDetected() {
+            Product product = Product.create(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, null, null, null, "설명"
+            );
+            Instant newStart = Instant.now().plus(1, ChronoUnit.DAYS);
+            Instant newEnd = Instant.now().plus(10, ChronoUnit.DAYS);
+
+            Set<String> changedFields = product.modify(
+                    "상품명", 10000L, 10000L, "KRW",
+                    ProductCategory.FIGURE, newStart, newEnd, "https://cdn.example.com/thumb.jpg", "설명"
+            );
+
+            assertThat(changedFields).containsExactlyInAnyOrder("saleStartAt", "saleEndAt", "thumbnailUrl");
         }
     }
 


### PR DESCRIPTION

- 상품의 상태변경 / 정보 수정 시 이벤트를 발행하도록 변경
    - catalog-service 추가 대비


| Topic | 발행 시점 | 페이로드 |
|---|---|---|
| `product.activated` | 상태가 `ACTIVE`로 전이 (`DRAFT→ACTIVE`, `INACTIVE→ACTIVE`) | 상품 전체 스냅샷 |
| `product.deactivated` | 상태가 `INACTIVE`로 전이 (`ACTIVE→INACTIVE`) | `productId` |
| `product.discontinued` | `ACTIVE`/`INACTIVE`에서 `DISCONTINUED`로 전이 | `productId` |
| `product.modified` | `ACTIVE`/`INACTIVE` 상태 상품의 필드가 실제로 변경된 경우 | 상품 전체 스냅샷 |