### PR TITLE
판매 시작 도래 상품 자동 활성화 스케줄러 추가  

### DIFF
--- a/service/product-service/src/main/java/dev/labs/commerce/product/api/scheduling/ProductActivationScheduler.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/api/scheduling/ProductActivationScheduler.java
@@ -1,0 +1,45 @@
+package dev.labs.commerce.product.api.scheduling;
+
+import dev.labs.commerce.product.config.ProductActivationProperties;
+import dev.labs.commerce.product.core.product.application.usecase.ActivateScheduledProductUseCase;
+import dev.labs.commerce.product.core.product.application.usecase.dto.ActivateScheduledProductCommand;
+import dev.labs.commerce.product.core.product.domain.ProductDao;
+import dev.labs.commerce.product.core.product.domain.ProductStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProductActivationScheduler {
+
+    private final ProductDao productDao;
+    private final ActivateScheduledProductUseCase activateScheduledProductUseCase;
+    private final ProductActivationProperties properties;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void activateScheduledProducts() {
+        Instant now = Instant.now();
+        List<Long> productIds = productDao.findIdsByStatusInSalePeriod(
+                ProductStatus.INACTIVE, now, properties.getBatchSize()
+        );
+
+        if (productIds.isEmpty()) {
+            return;
+        }
+
+        log.info("Activating {} products whose sale period has started", productIds.size());
+        productIds.forEach(productId -> {
+            try {
+                activateScheduledProductUseCase.execute(new ActivateScheduledProductCommand(productId));
+            } catch (Exception e) {
+                log.error("Failed to activate product: productId={}", productId, e);
+            }
+        });
+    }
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/config/ProductActivationConfig.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/config/ProductActivationConfig.java
@@ -1,0 +1,11 @@
+package dev.labs.commerce.product.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableConfigurationProperties(ProductActivationProperties.class)
+@EnableScheduling
+public class ProductActivationConfig {
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/config/ProductActivationProperties.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/config/ProductActivationProperties.java
@@ -1,0 +1,12 @@
+package dev.labs.commerce.product.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "product.activation")
+@Getter
+@Setter
+public class ProductActivationProperties {
+    private int batchSize = 100;
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/config/QueryDslConfig.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package dev.labs.commerce.product.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ActivateScheduledProductUseCase.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/ActivateScheduledProductUseCase.java
@@ -1,0 +1,52 @@
+package dev.labs.commerce.product.core.product.application.usecase;
+
+import dev.labs.commerce.product.core.product.application.event.ProductActivatedEvent;
+import dev.labs.commerce.product.core.product.application.event.ProductEventPublisher;
+import dev.labs.commerce.product.core.product.application.usecase.dto.ActivateScheduledProductCommand;
+import dev.labs.commerce.product.core.product.domain.Product;
+import dev.labs.commerce.product.core.product.domain.ProductRepository;
+import dev.labs.commerce.product.core.product.domain.ProductStatus;
+import dev.labs.commerce.product.core.product.domain.error.ProductErrorCode;
+import dev.labs.commerce.product.core.product.domain.error.ProductNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class ActivateScheduledProductUseCase {
+
+    private final ProductRepository productRepository;
+    private final ProductEventPublisher productEventPublisher;
+
+    public void execute(ActivateScheduledProductCommand command) {
+        Product product = productRepository.findById(command.productId())
+                .orElseThrow(() -> new ProductNotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND, "Product not found: " + command.productId()));
+
+        ProductStatus previousStatus = product.getProductStatus();
+        if (previousStatus == ProductStatus.ACTIVE) {
+            return;
+        }
+
+        product.changeStatus(ProductStatus.ACTIVE);
+        productRepository.save(product);
+
+        productEventPublisher.publishProductActivated(new ProductActivatedEvent(
+                product.getProductId(),
+                product.getProductName(),
+                product.getListPrice(),
+                product.getSellingPrice(),
+                product.getCurrency(),
+                product.getCategory(),
+                product.getSaleStartAt(),
+                product.getSaleEndAt(),
+                product.getThumbnailUrl(),
+                product.getDescription()
+        ));
+
+        log.info("Product activated by scheduler: productId={}", product.getProductId());
+    }
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ActivateScheduledProductCommand.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/application/usecase/dto/ActivateScheduledProductCommand.java
@@ -1,0 +1,4 @@
+package dev.labs.commerce.product.core.product.application.usecase.dto;
+
+public record ActivateScheduledProductCommand(Long productId) {
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/ProductDao.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/ProductDao.java
@@ -6,12 +6,12 @@ import java.util.List;
 public interface ProductDao {
 
     /**
-     * 지정한 시각(at) 기준으로 판매 기간 내에 있는 특정 상태의 상품을 조회한다.
+     * 지정한 시각(at) 기준으로 판매 기간 내에 있는 특정 상태의 상품 id 목록을 조회한다.
      * 조건: productStatus = status
      *      AND saleStartAt <= at
      *      AND (saleEndAt IS NULL OR saleEndAt > at)
      * 정렬: saleStartAt ASC, productId ASC
      */
-    List<Product> findByStatusInSalePeriod(ProductStatus status, Instant at, int limit);
+    List<Long> findIdsByStatusInSalePeriod(ProductStatus status, Instant at, int limit);
 
 }

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/ProductDao.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/domain/ProductDao.java
@@ -1,0 +1,17 @@
+package dev.labs.commerce.product.core.product.domain;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface ProductDao {
+
+    /**
+     * 지정한 시각(at) 기준으로 판매 기간 내에 있는 특정 상태의 상품을 조회한다.
+     * 조건: productStatus = status
+     *      AND saleStartAt <= at
+     *      AND (saleEndAt IS NULL OR saleEndAt > at)
+     * 정렬: saleStartAt ASC, productId ASC
+     */
+    List<Product> findByStatusInSalePeriod(ProductStatus status, Instant at, int limit);
+
+}

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/infra/persistence/ProductDaoImpl.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/infra/persistence/ProductDaoImpl.java
@@ -1,7 +1,6 @@
 package dev.labs.commerce.product.core.product.infra.persistence;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import dev.labs.commerce.product.core.product.domain.Product;
 import dev.labs.commerce.product.core.product.domain.ProductDao;
 import dev.labs.commerce.product.core.product.domain.ProductStatus;
 import dev.labs.commerce.product.core.product.domain.QProduct;
@@ -18,9 +17,10 @@ public class ProductDaoImpl implements ProductDao {
     private final JPAQueryFactory factory;
 
     @Override
-    public List<Product> findByStatusInSalePeriod(ProductStatus status, Instant at, int limit) {
+    public List<Long> findIdsByStatusInSalePeriod(ProductStatus status, Instant at, int limit) {
         QProduct product = QProduct.product;
-        return factory.selectFrom(product)
+        return factory.select(product.productId)
+                .from(product)
                 .where(
                         product.productStatus.eq(status),
                         product.saleStartAt.loe(at),

--- a/service/product-service/src/main/java/dev/labs/commerce/product/core/product/infra/persistence/ProductDaoImpl.java
+++ b/service/product-service/src/main/java/dev/labs/commerce/product/core/product/infra/persistence/ProductDaoImpl.java
@@ -1,0 +1,34 @@
+package dev.labs.commerce.product.core.product.infra.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dev.labs.commerce.product.core.product.domain.Product;
+import dev.labs.commerce.product.core.product.domain.ProductDao;
+import dev.labs.commerce.product.core.product.domain.ProductStatus;
+import dev.labs.commerce.product.core.product.domain.QProduct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductDaoImpl implements ProductDao {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public List<Product> findByStatusInSalePeriod(ProductStatus status, Instant at, int limit) {
+        QProduct product = QProduct.product;
+        return factory.selectFrom(product)
+                .where(
+                        product.productStatus.eq(status),
+                        product.saleStartAt.loe(at),
+                        product.saleEndAt.isNull().or(product.saleEndAt.gt(at))
+                )
+                .orderBy(product.saleStartAt.asc(), product.productId.asc())
+                .limit(limit)
+                .fetch();
+    }
+
+}

--- a/service/product-service/src/main/resources/application.yml
+++ b/service/product-service/src/main/resources/application.yml
@@ -66,3 +66,7 @@ springdoc:
     doc-expansion: none
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+product:
+  activation:
+    batch-size: 100


### PR DESCRIPTION
## 문제

Product 모델 확장(#39)으로 `saleStartAt/saleEndAt` 필드와 `DRAFT/INACTIVE/ACTIVE/DISCONTINUED` 상태 전이 규칙이 정비됐지만, 판매 시작 시각이 도래했을 때 상품을 `ACTIVE`로 전이시키는 수단이 없다. 현재는 `PATCH /products/{id}/status`로 운영자가 수동으로 활성화해야 한다.

특히 `Product.isScheduled()`는 "`INACTIVE` + `saleStartAt`이 미래"인 예약 판매 상품을 판별하는 도메인 로직을 이미 가지고 있으나, 이를 주기적으로 검사해 활성화하는 주체가 존재하지 않았다.

## 해결 방법

product-service에 활성화 스케줄러를 추가해 판매 시작 시각이 도래한 `INACTIVE` 상품을 주기적으로 `ACTIVE`로 전이시킨다. 기존 order-expiry / payment-expiry 스케줄러와 동일한 패턴을 따른다.

**흐름**

```
ProductActivationScheduler (1분 주기)
  → ProductDao.findIdsByStatusInSalePeriod(INACTIVE, now, batchSize)
      -- saleStartAt <= now AND (saleEndAt IS NULL OR saleEndAt > now)
  → ActivateScheduledProductUseCase (단건, 독립 트랜잭션)
      → product.changeStatus(ACTIVE)
      → product.activated 이벤트 발행 (afterCommit)
  → (구독 예정) catalog-service: 상품 노출
```

## 설계 결정

**`ChangeProductStatusUseCase` 재사용 대신 전용 UseCase 신설**

기존 `ChangeProductStatusUseCase`는 HTTP 엔트리 포인트(`PATCH /products/{id}/status`)에서 호출되는 운영자용 API의 유스케이스다. 스케줄러가 HTTP용 UseCase를 직접 재사용하는 것은 선례(`ExpireOrderUseCase`, `ExpirePaymentUseCase` — 각각 전용 UseCase로 분리)와 어긋나므로 `ActivateScheduledProductUseCase`를 별도로 추가했다. 로직은 `ChangeProductStatusUseCase`의 `ACTIVE` 전이 케이스와 사실상 동일하지만, 진입점과 트랜잭션 경계를 분리하는 편이 향후 "스케줄러에서만 적용할 정책"(예: 실패 재시도, 알림)이 생길 때 수정 범위를 좁힐 수 있다.

**DAO는 `productId`만 반환**

선례(`PaymentDao.findIdsByStatusAndRequestedAtBefore`, `SalesOrderRepository.findOrderIdsByStatusAndOrderCreatedAtBefore`)에 맞춰 배치 조회는 id 목록만 반환하고, 각 UseCase가 자체 트랜잭션 안에서 엔티티를 다시 로드한다. 초기 구현에서 `List<Product>`로 돌려주던 것을 리팩터 커밋으로 정리했다.

**`saleEndAt` 이미 지난 상품은 제외**

`saleStartAt`만 확인하면 판매 기간이 이미 끝난 상품도 활성화하게 된다. DAO 쿼리에 `saleEndAt IS NULL OR saleEndAt > at` 조건을 포함해 아직 유효한 판매 기간의 상품만 대상에 넣는다.

**멱등성**

- DAO가 `productStatus = INACTIVE`로 필터하므로 이미 `ACTIVE`인 상품은 애초에 조회되지 않는다
- 조회 후 UseCase 실행 사이 경합으로 이미 `ACTIVE`가 된 경우를 대비해 UseCase 내부에서 `previousStatus == ACTIVE`면 조용히 skip
- 건별 try/catch로 한 건 실패가 나머지 배치 진행을 막지 않도록 격리