### PR TITLE
order-service 통합테스트 추가

### DIFF
--- a/service/order-service/build.gradle.kts
+++ b/service/order-service/build.gradle.kts
@@ -35,6 +35,12 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-stream-kafka")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:kafka")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+    testImplementation("org.awaitility:awaitility")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
@@ -11,7 +11,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -41,78 +40,52 @@ class InventoryEventsConsumerIntegrationTest extends AbstractIntegrationTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Nested
-    @DisplayName("재고 예약 실패 이벤트 수신")
-    class StockReservationFailed {
-
-        @Test
-        @DisplayName("이벤트가 도착하면 해당 주문이 ABORTED로 전이된다")
-        void event_consumed_transitionsOrderToAborted() {
-            // given
-            SalesOrder order = salesOrderRepository.saveAndFlush(
-                    SalesOrderFixture.builder().withSample().build());
-
-            // when
-            sendEvent(order.getOrderId());
-
-            // then
-            awaitOrderStatus(order.getOrderId(), OrderStatus.ABORTED);
-        }
-
-        @Test
-        @DisplayName("이미 ABORTED인 주문에 이벤트가 다시 도착해도 상태가 변하지 않는다")
-        void alreadyAborted_remainsAborted() {
-            // given : ABORTED 상태로 직접 시드
-            Instant originalAbortedAt = Instant.parse("2026-01-01T00:00:00Z");
-            SalesOrder order = salesOrderRepository.saveAndFlush(
-                    SalesOrderFixture.builder()
-                            .withSample()
-                            .status(OrderStatus.ABORTED)
-                            .abortedAt(originalAbortedAt)
-                            .build());
-
-            // when
-            sendEvent(order.getOrderId());
-
-            // then : 2초 동안 상태/abortedAt이 모두 그대로 유지됨
-            Awaitility.await()
-                    .during(Duration.ofSeconds(2))
-                    .atMost(Duration.ofSeconds(3))
-                    .untilAsserted(() -> {
-                        SalesOrder reloaded = salesOrderRepository.findById(order.getOrderId()).orElseThrow();
-                        assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
-                        assertThat(reloaded.getAbortedAt()).isEqualTo(originalAbortedAt);
-                    });
-        }
-
-        // 존재하지 않는 orderId 이벤트는 OrderNotFoundException → Spring Cloud Stream 기본
-        // 재시도(3회) 후 drop된다. 후속 정상 이벤트가 같은 partition에 있어도 처리되는지를
-        // 검증해, 한 메시지 실패가 컨슈머 전체를 막지 않는 회복력을 보장한다.
-        // 이 테스트는 의도적으로 OrderNotFoundException 스택트레이스가 로그에 남는다.
-        @Test
-        @DisplayName("존재하지 않는 주문 이벤트가 와도 후속 정상 이벤트는 처리된다")
-        void unknownOrder_doesNotBlockSubsequentMessages() {
-            // given
-            SalesOrder normalOrder = salesOrderRepository.saveAndFlush(
-                    SalesOrderFixture.builder().withSample().build());
-            String unknownOrderId = "unknown-" + UUID.randomUUID();
-
-            // when : 잘못된 메시지를 먼저, 정상 메시지를 뒤에 발송
-            sendEvent(unknownOrderId);
-            sendEvent(normalOrder.getOrderId());
-
-            // then : 정상 주문은 결국 ABORTED로 전이됨 (재시도 backoff 후)
-            Awaitility.await()
-                    .atMost(Duration.ofSeconds(30))
-                    .pollInterval(Duration.ofMillis(500))
-                    .untilAsserted(() -> {
-                        SalesOrder reloaded = salesOrderRepository.findById(normalOrder.getOrderId()).orElseThrow();
-                        assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
-                    });
-        }
+    @Test
+    @DisplayName("재고 예약 실패 이벤트가 도착하면 해당 주문이 ABORTED로 전이된다")
+    void event_consumed_transitionsOrderToAborted() {
+        SalesOrder order = salesOrderRepository.saveAndFlush(
+                SalesOrderFixture.builder().withSample().build());
+        sendEvent(order.getOrderId());
+        awaitOrderStatus(order.getOrderId(), OrderStatus.ABORTED);
     }
 
-    // --- helpers ---
+    @Test
+    @DisplayName("이미 ABORTED인 주문에 이벤트가 다시 도착해도 상태가 변하지 않는다")
+    void alreadyAborted_remainsAborted() {
+        Instant originalAbortedAt = Instant.parse("2026-01-01T00:00:00Z");
+        SalesOrder order = salesOrderRepository.saveAndFlush(
+                SalesOrderFixture.builder()
+                        .withSample()
+                        .status(OrderStatus.ABORTED)
+                        .abortedAt(originalAbortedAt)
+                        .build());
+        sendEvent(order.getOrderId());
+        Awaitility.await()
+                .during(Duration.ofSeconds(2))
+                .atMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> {
+                    SalesOrder reloaded = salesOrderRepository.findById(order.getOrderId()).orElseThrow();
+                    assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
+                    assertThat(reloaded.getAbortedAt()).isEqualTo(originalAbortedAt);
+                });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 주문 이벤트가 와도 후속 정상 이벤트는 처리된다")
+    void unknownOrder_doesNotBlockSubsequentMessages() {
+        SalesOrder normalOrder = salesOrderRepository.saveAndFlush(
+                SalesOrderFixture.builder().withSample().build());
+        String unknownOrderId = "unknown-" + UUID.randomUUID();
+        sendEvent(unknownOrderId);
+        sendEvent(normalOrder.getOrderId());
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    SalesOrder reloaded = salesOrderRepository.findById(normalOrder.getOrderId()).orElseThrow();
+                    assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
+                });
+    }
 
     private void sendEvent(String orderId) {
         kafkaTemplate.send("stock.reservation.failed", orderId, buildEnvelopeJson(orderId));

--- a/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
@@ -11,6 +11,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,27 +41,81 @@ class InventoryEventsConsumerIntegrationTest extends AbstractIntegrationTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Test
-    @DisplayName("재고 예약 실패 이벤트가 도착하면 해당 주문이 ABORTED로 전이된다")
-    void stockReservationFailedEvent_consumed_transitionsOrderToAborted() {
-        // given
-        SalesOrder order = salesOrderRepository.saveAndFlush(
-                SalesOrderFixture.builder().withSample().build());
+    @Nested
+    @DisplayName("재고 예약 실패 이벤트 수신")
+    class StockReservationFailed {
 
-        String envelopeJson = buildEnvelopeJson(order.getOrderId());
+        @Test
+        @DisplayName("이벤트가 도착하면 해당 주문이 ABORTED로 전이된다")
+        void event_consumed_transitionsOrderToAborted() {
+            // given
+            SalesOrder order = salesOrderRepository.saveAndFlush(
+                    SalesOrderFixture.builder().withSample().build());
 
-        // when
-        kafkaTemplate.send("stock.reservation.failed", order.getOrderId(), envelopeJson);
+            // when
+            sendEvent(order.getOrderId());
 
-        // then
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(15))
-                .pollInterval(Duration.ofMillis(200))
-                .untilAsserted(() -> {
-                    SalesOrder reloaded = salesOrderRepository.findById(order.getOrderId()).orElseThrow();
-                    assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
-                    assertThat(reloaded.getAbortedAt()).isNotNull();
-                });
+            // then
+            awaitOrderStatus(order.getOrderId(), OrderStatus.ABORTED);
+        }
+
+        @Test
+        @DisplayName("이미 ABORTED인 주문에 이벤트가 다시 도착해도 상태가 변하지 않는다")
+        void alreadyAborted_remainsAborted() {
+            // given : ABORTED 상태로 직접 시드
+            Instant originalAbortedAt = Instant.parse("2026-01-01T00:00:00Z");
+            SalesOrder order = salesOrderRepository.saveAndFlush(
+                    SalesOrderFixture.builder()
+                            .withSample()
+                            .status(OrderStatus.ABORTED)
+                            .abortedAt(originalAbortedAt)
+                            .build());
+
+            // when
+            sendEvent(order.getOrderId());
+
+            // then : 2초 동안 상태/abortedAt이 모두 그대로 유지됨
+            Awaitility.await()
+                    .during(Duration.ofSeconds(2))
+                    .atMost(Duration.ofSeconds(3))
+                    .untilAsserted(() -> {
+                        SalesOrder reloaded = salesOrderRepository.findById(order.getOrderId()).orElseThrow();
+                        assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
+                        assertThat(reloaded.getAbortedAt()).isEqualTo(originalAbortedAt);
+                    });
+        }
+
+        // 존재하지 않는 orderId 이벤트는 OrderNotFoundException → Spring Cloud Stream 기본
+        // 재시도(3회) 후 drop된다. 후속 정상 이벤트가 같은 partition에 있어도 처리되는지를
+        // 검증해, 한 메시지 실패가 컨슈머 전체를 막지 않는 회복력을 보장한다.
+        // 이 테스트는 의도적으로 OrderNotFoundException 스택트레이스가 로그에 남는다.
+        @Test
+        @DisplayName("존재하지 않는 주문 이벤트가 와도 후속 정상 이벤트는 처리된다")
+        void unknownOrder_doesNotBlockSubsequentMessages() {
+            // given
+            SalesOrder normalOrder = salesOrderRepository.saveAndFlush(
+                    SalesOrderFixture.builder().withSample().build());
+            String unknownOrderId = "unknown-" + UUID.randomUUID();
+
+            // when : 잘못된 메시지를 먼저, 정상 메시지를 뒤에 발송
+            sendEvent(unknownOrderId);
+            sendEvent(normalOrder.getOrderId());
+
+            // then : 정상 주문은 결국 ABORTED로 전이됨 (재시도 backoff 후)
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(30))
+                    .pollInterval(Duration.ofMillis(500))
+                    .untilAsserted(() -> {
+                        SalesOrder reloaded = salesOrderRepository.findById(normalOrder.getOrderId()).orElseThrow();
+                        assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
+                    });
+        }
+    }
+
+    // --- helpers ---
+
+    private void sendEvent(String orderId) {
+        kafkaTemplate.send("stock.reservation.failed", orderId, buildEnvelopeJson(orderId));
     }
 
     private String buildEnvelopeJson(String orderId) {
@@ -75,6 +130,16 @@ class InventoryEventsConsumerIntegrationTest extends AbstractIntegrationTest {
         payload.put("quantity", 2);
         payload.put("errorCode", "OUT_OF_STOCK");
         return envelope.toString();
+    }
+
+    private void awaitOrderStatus(String orderId, OrderStatus expected) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    SalesOrder reloaded = salesOrderRepository.findById(orderId).orElseThrow();
+                    assertThat(reloaded.getStatus()).isEqualTo(expected);
+                });
     }
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
@@ -2,10 +2,10 @@ package dev.labs.commerce.order.api.messaging;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import dev.labs.commerce.order.core.order.domain.OrderItem;
 import dev.labs.commerce.order.core.order.domain.OrderStatus;
 import dev.labs.commerce.order.core.order.domain.SalesOrder;
 import dev.labs.commerce.order.core.order.domain.SalesOrderRepository;
+import dev.labs.commerce.order.core.order.domain.fixture.SalesOrderFixture;
 import dev.labs.commerce.order.support.AbstractIntegrationTest;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -23,7 +23,6 @@ import org.springframework.kafka.core.KafkaTemplate;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -45,9 +44,8 @@ class InventoryEventsConsumerIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("재고 예약 실패 이벤트가 도착하면 해당 주문이 ABORTED로 전이된다")
     void stockReservationFailedEvent_consumed_transitionsOrderToAborted() {
         // given
-        OrderItem item = OrderItem.create(1L, "상품A", 5000L, 2, "KRW");
-        SalesOrder order = SalesOrder.create(100L, "KRW", List.of(item), Instant.now());
-        salesOrderRepository.saveAndFlush(order);
+        SalesOrder order = salesOrderRepository.saveAndFlush(
+                SalesOrderFixture.builder().withSample().build());
 
         String envelopeJson = buildEnvelopeJson(order.getOrderId());
 

--- a/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
@@ -1,0 +1,95 @@
+package dev.labs.commerce.order.api.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.labs.commerce.order.core.order.domain.OrderItem;
+import dev.labs.commerce.order.core.order.domain.OrderStatus;
+import dev.labs.commerce.order.core.order.domain.SalesOrder;
+import dev.labs.commerce.order.core.order.domain.SalesOrderRepository;
+import dev.labs.commerce.order.support.AbstractIntegrationTest;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(InventoryEventsConsumerIntegrationTest.TestKafkaProducerConfig.class)
+class InventoryEventsConsumerIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private SalesOrderRepository salesOrderRepository;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("재고 예약 실패 이벤트가 도착하면 해당 주문이 ABORTED로 전이된다")
+    void stockReservationFailedEvent_consumed_transitionsOrderToAborted() {
+        // given
+        OrderItem item = OrderItem.create(1L, "상품A", 5000L, 2, "KRW");
+        SalesOrder order = SalesOrder.create(100L, "KRW", List.of(item), Instant.now());
+        salesOrderRepository.saveAndFlush(order);
+
+        String envelopeJson = buildEnvelopeJson(order.getOrderId());
+
+        // when
+        kafkaTemplate.send("stock.reservation.failed", order.getOrderId(), envelopeJson);
+
+        // then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    SalesOrder reloaded = salesOrderRepository.findById(order.getOrderId()).orElseThrow();
+                    assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
+                    assertThat(reloaded.getAbortedAt()).isNotNull();
+                });
+    }
+
+    private String buildEnvelopeJson(String orderId) {
+        ObjectNode envelope = objectMapper.createObjectNode();
+        ObjectNode meta = envelope.putObject("meta");
+        meta.put("eventId", UUID.randomUUID().toString());
+        meta.put("eventType", "StockReservationFailedEvent");
+        meta.put("occurredAt", Instant.now().toString());
+        ObjectNode payload = envelope.putObject("payload");
+        payload.put("productId", 1);
+        payload.put("orderId", orderId);
+        payload.put("quantity", 2);
+        payload.put("errorCode", "OUT_OF_STOCK");
+        return envelope.toString();
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestKafkaProducerConfig {
+
+        @Bean
+        KafkaTemplate<String, String> testKafkaTemplate(
+                @Value("${spring.cloud.stream.kafka.binder.brokers}") String bootstrapServers) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(config));
+        }
+    }
+}

--- a/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/PaymentEventsConsumerIntegrationTest.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/PaymentEventsConsumerIntegrationTest.java
@@ -3,10 +3,10 @@ package dev.labs.commerce.order.api.messaging;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import dev.labs.commerce.order.core.order.domain.OrderItem;
 import dev.labs.commerce.order.core.order.domain.OrderStatus;
 import dev.labs.commerce.order.core.order.domain.SalesOrder;
 import dev.labs.commerce.order.core.order.domain.SalesOrderRepository;
+import dev.labs.commerce.order.core.order.domain.fixture.SalesOrderFixture;
 import dev.labs.commerce.order.support.AbstractIntegrationTest;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -41,7 +41,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PaymentEventsConsumerIntegrationTest extends AbstractIntegrationTest {
 
     private static final long CUSTOMER_ID = 100L;
-    private static final long UNIT_PRICE = 5000L;
     private static final int QUANTITY = 2;
     private static final String CURRENCY = "KRW";
 
@@ -158,16 +157,17 @@ class PaymentEventsConsumerIntegrationTest extends AbstractIntegrationTest {
     // --- helpers ---
 
     private SalesOrder saveCreatedOrder() {
-        OrderItem item = OrderItem.create(1L, "상품A", UNIT_PRICE, QUANTITY, CURRENCY);
-        SalesOrder order = SalesOrder.create(CUSTOMER_ID, CURRENCY, List.of(item), Instant.now());
-        return salesOrderRepository.saveAndFlush(order);
+        return salesOrderRepository.saveAndFlush(
+                SalesOrderFixture.builder().withSample().build());
     }
 
     private SalesOrder savePendingOrder() {
-        OrderItem item = OrderItem.create(1L, "상품A", UNIT_PRICE, QUANTITY, CURRENCY);
-        SalesOrder order = SalesOrder.create(CUSTOMER_ID, CURRENCY, List.of(item), Instant.now());
-        order.markAsPending(Instant.now());
-        return salesOrderRepository.saveAndFlush(order);
+        return salesOrderRepository.saveAndFlush(
+                SalesOrderFixture.builder()
+                        .withSample()
+                        .status(OrderStatus.PENDING)
+                        .pendingAt(Instant.now())
+                        .build());
     }
 
     private void sendEnvelope(String topic, String eventType, ObjectNode payload, String key) {

--- a/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/PaymentEventsConsumerIntegrationTest.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/PaymentEventsConsumerIntegrationTest.java
@@ -1,0 +1,226 @@
+package dev.labs.commerce.order.api.messaging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.labs.commerce.order.core.order.domain.OrderItem;
+import dev.labs.commerce.order.core.order.domain.OrderStatus;
+import dev.labs.commerce.order.core.order.domain.SalesOrder;
+import dev.labs.commerce.order.core.order.domain.SalesOrderRepository;
+import dev.labs.commerce.order.support.AbstractIntegrationTest;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(PaymentEventsConsumerIntegrationTest.TestKafkaProducerConfig.class)
+class PaymentEventsConsumerIntegrationTest extends AbstractIntegrationTest {
+
+    private static final long CUSTOMER_ID = 100L;
+    private static final long UNIT_PRICE = 5000L;
+    private static final int QUANTITY = 2;
+    private static final String CURRENCY = "KRW";
+
+    @Autowired
+    private SalesOrderRepository salesOrderRepository;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value("${spring.cloud.stream.kafka.binder.brokers}")
+    private String bootstrapServers;
+
+    @Nested
+    @DisplayName("결제 초기화 이벤트 수신")
+    class PaymentInitialized {
+
+        @Test
+        @DisplayName("주문이 CREATED 상태일 때 결제 초기화 이벤트가 도착하면 PENDING으로 전이된다")
+        void paymentInitializedEvent_consumed_transitionsCreatedOrderToPending() {
+            // given
+            SalesOrder order = saveCreatedOrder();
+            ObjectNode payload = objectMapper.createObjectNode()
+                    .put("paymentId", "pay-" + UUID.randomUUID())
+                    .put("orderId", order.getOrderId())
+                    .put("requestedAt", Instant.now().toString());
+
+            // when
+            sendEnvelope("payment.initialized", "PaymentInitializedEvent", payload, order.getOrderId());
+
+            // then
+            awaitOrderStatus(order.getOrderId(), OrderStatus.PENDING);
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 승인 이벤트 수신")
+    class PaymentApproved {
+
+        @Test
+        @DisplayName("PENDING 주문에 결제 승인 이벤트가 도착하면 PAID로 전이되고 order.paid가 발행된다")
+        void paymentApprovedEvent_consumed_transitionsToPaidAndPublishesOrderPaid() {
+            // given
+            SalesOrder order = savePendingOrder();
+            ObjectNode payload = objectMapper.createObjectNode()
+                    .put("orderId", order.getOrderId())
+                    .put("customerId", CUSTOMER_ID)
+                    .put("amount", order.getTotalPrice())
+                    .put("currency", CURRENCY);
+
+            try (Consumer<String, String> orderPaidConsumer = subscribingConsumer("order.paid")) {
+                // when
+                sendEnvelope("payment.approved", "PaymentApprovedEvent", payload, order.getOrderId());
+
+                // then : DB 상태
+                awaitOrderStatus(order.getOrderId(), OrderStatus.PAID);
+
+                // then : outbound order.paid 발행
+                ConsumerRecord<String, String> record = KafkaTestUtils.getSingleRecord(
+                        orderPaidConsumer, "order.paid", Duration.ofSeconds(10));
+                assertThat(record.key()).isEqualTo(order.getOrderId());
+
+                JsonNode envelope = readJson(record.value());
+                assertThat(envelope.path("meta").path("eventType").asText()).isEqualTo("OrderPaidEvent");
+                assertThat(envelope.path("payload").path("orderId").asText()).isEqualTo(order.getOrderId());
+                assertThat(envelope.path("payload").path("items")).hasSize(1);
+                assertThat(envelope.path("payload").path("items").get(0).path("quantity").asInt()).isEqualTo(QUANTITY);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 실패 이벤트 수신")
+    class PaymentFailed {
+
+        @Test
+        @DisplayName("PENDING 주문에 결제 실패 이벤트가 도착하면 ABORTED로 전이된다")
+        void paymentFailedEvent_consumed_transitionsToAborted() {
+            // given
+            SalesOrder order = savePendingOrder();
+            ObjectNode payload = objectMapper.createObjectNode()
+                    .put("orderId", order.getOrderId())
+                    .put("failureCode", "PG_DECLINED");
+
+            // when
+            sendEnvelope("payment.failed", "PaymentFailedEvent", payload, order.getOrderId());
+
+            // then
+            awaitOrderStatus(order.getOrderId(), OrderStatus.ABORTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 만료 이벤트 수신")
+    class PaymentExpired {
+
+        @Test
+        @DisplayName("PENDING 주문에 결제 만료 이벤트가 도착하면 EXPIRED로 전이된다")
+        void paymentExpiredEvent_consumed_transitionsToExpired() {
+            // given
+            SalesOrder order = savePendingOrder();
+            ObjectNode payload = objectMapper.createObjectNode().put("orderId", order.getOrderId());
+
+            // when
+            sendEnvelope("payment.expired", "PaymentExpiredEvent", payload, order.getOrderId());
+
+            // then
+            awaitOrderStatus(order.getOrderId(), OrderStatus.EXPIRED);
+        }
+    }
+
+    // --- helpers ---
+
+    private SalesOrder saveCreatedOrder() {
+        OrderItem item = OrderItem.create(1L, "상품A", UNIT_PRICE, QUANTITY, CURRENCY);
+        SalesOrder order = SalesOrder.create(CUSTOMER_ID, CURRENCY, List.of(item), Instant.now());
+        return salesOrderRepository.saveAndFlush(order);
+    }
+
+    private SalesOrder savePendingOrder() {
+        OrderItem item = OrderItem.create(1L, "상품A", UNIT_PRICE, QUANTITY, CURRENCY);
+        SalesOrder order = SalesOrder.create(CUSTOMER_ID, CURRENCY, List.of(item), Instant.now());
+        order.markAsPending(Instant.now());
+        return salesOrderRepository.saveAndFlush(order);
+    }
+
+    private void sendEnvelope(String topic, String eventType, ObjectNode payload, String key) {
+        ObjectNode envelope = objectMapper.createObjectNode();
+        ObjectNode meta = envelope.putObject("meta");
+        meta.put("eventId", UUID.randomUUID().toString());
+        meta.put("eventType", eventType);
+        meta.put("occurredAt", Instant.now().toString());
+        envelope.set("payload", payload);
+        kafkaTemplate.send(topic, key, envelope.toString());
+    }
+
+    private void awaitOrderStatus(String orderId, OrderStatus expected) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    SalesOrder reloaded = salesOrderRepository.findById(orderId).orElseThrow();
+                    assertThat(reloaded.getStatus()).isEqualTo(expected);
+                });
+    }
+
+    private Consumer<String, String> subscribingConsumer(String topic) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-listener-" + UUID.randomUUID());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        Consumer<String, String> consumer = new DefaultKafkaConsumerFactory<>(
+                props, new StringDeserializer(), new StringDeserializer()).createConsumer();
+        consumer.subscribe(List.of(topic));
+        consumer.poll(Duration.ofMillis(500));
+        return consumer;
+    }
+
+    private JsonNode readJson(String value) {
+        try {
+            return objectMapper.readTree(value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestKafkaProducerConfig {
+
+        @Bean
+        KafkaTemplate<String, String> testKafkaTemplate(
+                @Value("${spring.cloud.stream.kafka.binder.brokers}") String bootstrapServers) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(config));
+        }
+    }
+}

--- a/service/order-service/src/test/java/dev/labs/commerce/order/core/order/domain/fixture/OrderItemFixture.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/core/order/domain/fixture/OrderItemFixture.java
@@ -1,0 +1,73 @@
+package dev.labs.commerce.order.core.order.domain.fixture;
+
+import dev.labs.commerce.order.core.order.domain.OrderItem;
+import org.springframework.beans.BeanUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class OrderItemFixture {
+
+    private long productId;
+    private String productName;
+    private long unitPrice;
+    private int quantity;
+    private long lineAmount;
+    private String currency;
+
+    private OrderItemFixture() {
+    }
+
+    public static OrderItemFixture builder() {
+        return new OrderItemFixture();
+    }
+
+    public OrderItemFixture productId(long productId) {
+        this.productId = productId;
+        return this;
+    }
+
+    public OrderItemFixture productName(String productName) {
+        this.productName = productName;
+        return this;
+    }
+
+    public OrderItemFixture unitPrice(long unitPrice) {
+        this.unitPrice = unitPrice;
+        return this;
+    }
+
+    public OrderItemFixture quantity(int quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    public OrderItemFixture lineAmount(long lineAmount) {
+        this.lineAmount = lineAmount;
+        return this;
+    }
+
+    public OrderItemFixture currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    public OrderItemFixture withSample() {
+        this.productId = 1L;
+        this.productName = "상품A";
+        this.unitPrice = 5000L;
+        this.quantity = 2;
+        this.lineAmount = unitPrice * quantity;
+        this.currency = "KRW";
+        return this;
+    }
+
+    public OrderItem build() {
+        OrderItem item = BeanUtils.instantiateClass(OrderItem.class);
+        ReflectionTestUtils.setField(item, "productId", productId);
+        ReflectionTestUtils.setField(item, "productName", productName);
+        ReflectionTestUtils.setField(item, "unitPrice", unitPrice);
+        ReflectionTestUtils.setField(item, "quantity", quantity);
+        ReflectionTestUtils.setField(item, "lineAmount", lineAmount);
+        ReflectionTestUtils.setField(item, "currency", currency);
+        return item;
+    }
+}

--- a/service/order-service/src/test/java/dev/labs/commerce/order/core/order/domain/fixture/SalesOrderFixture.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/core/order/domain/fixture/SalesOrderFixture.java
@@ -1,0 +1,138 @@
+package dev.labs.commerce.order.core.order.domain.fixture;
+
+import dev.labs.commerce.order.core.order.domain.OrderItem;
+import dev.labs.commerce.order.core.order.domain.OrderStatus;
+import dev.labs.commerce.order.core.order.domain.SalesOrder;
+import org.springframework.beans.BeanUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class SalesOrderFixture {
+
+    private String orderId;
+    private long customerId;
+    private OrderStatus status;
+    private long totalPrice;
+    private long totalAmount;
+    private String currency;
+    private List<OrderItem> items;
+    private Instant orderCreatedAt;
+    private Instant pendingAt;
+    private Instant paidAt;
+    private Instant abortedAt;
+    private Instant cancelledAt;
+    private Instant failedAt;
+    private Instant expiredAt;
+
+    private SalesOrderFixture() {
+    }
+
+    public static SalesOrderFixture builder() {
+        return new SalesOrderFixture();
+    }
+
+    public SalesOrderFixture orderId(String orderId) {
+        this.orderId = orderId;
+        return this;
+    }
+
+    public SalesOrderFixture customerId(long customerId) {
+        this.customerId = customerId;
+        return this;
+    }
+
+    public SalesOrderFixture status(OrderStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    public SalesOrderFixture totalPrice(long totalPrice) {
+        this.totalPrice = totalPrice;
+        return this;
+    }
+
+    public SalesOrderFixture totalAmount(long totalAmount) {
+        this.totalAmount = totalAmount;
+        return this;
+    }
+
+    public SalesOrderFixture currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    public SalesOrderFixture items(List<OrderItem> items) {
+        this.items = new ArrayList<>(items);
+        return this;
+    }
+
+    public SalesOrderFixture orderCreatedAt(Instant orderCreatedAt) {
+        this.orderCreatedAt = orderCreatedAt;
+        return this;
+    }
+
+    public SalesOrderFixture pendingAt(Instant pendingAt) {
+        this.pendingAt = pendingAt;
+        return this;
+    }
+
+    public SalesOrderFixture paidAt(Instant paidAt) {
+        this.paidAt = paidAt;
+        return this;
+    }
+
+    public SalesOrderFixture abortedAt(Instant abortedAt) {
+        this.abortedAt = abortedAt;
+        return this;
+    }
+
+    public SalesOrderFixture cancelledAt(Instant cancelledAt) {
+        this.cancelledAt = cancelledAt;
+        return this;
+    }
+
+    public SalesOrderFixture failedAt(Instant failedAt) {
+        this.failedAt = failedAt;
+        return this;
+    }
+
+    public SalesOrderFixture expiredAt(Instant expiredAt) {
+        this.expiredAt = expiredAt;
+        return this;
+    }
+
+    public SalesOrderFixture withSample() {
+        this.orderId = UUID.randomUUID().toString();
+        this.customerId = 100L;
+        this.status = OrderStatus.CREATED;
+        this.currency = "KRW";
+        this.items = new ArrayList<>(List.of(OrderItemFixture.builder().withSample().build()));
+        this.totalPrice = items.stream().mapToLong(OrderItem::getLineAmount).sum();
+        this.totalAmount = items.stream().mapToLong(OrderItem::getQuantity).sum();
+        this.orderCreatedAt = Instant.now();
+        return this;
+    }
+
+    public SalesOrder build() {
+        SalesOrder order = BeanUtils.instantiateClass(SalesOrder.class);
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+        ReflectionTestUtils.setField(order, "customerId", customerId);
+        ReflectionTestUtils.setField(order, "status", status);
+        ReflectionTestUtils.setField(order, "totalPrice", totalPrice);
+        ReflectionTestUtils.setField(order, "totalAmount", totalAmount);
+        ReflectionTestUtils.setField(order, "currency", currency);
+        ReflectionTestUtils.setField(order, "items", items);
+        ReflectionTestUtils.setField(order, "orderCreatedAt", orderCreatedAt);
+        ReflectionTestUtils.setField(order, "pendingAt", pendingAt);
+        ReflectionTestUtils.setField(order, "paidAt", paidAt);
+        ReflectionTestUtils.setField(order, "abortedAt", abortedAt);
+        ReflectionTestUtils.setField(order, "cancelledAt", cancelledAt);
+        ReflectionTestUtils.setField(order, "failedAt", failedAt);
+        ReflectionTestUtils.setField(order, "expiredAt", expiredAt);
+        return order;
+    }
+}

--- a/service/order-service/src/test/java/dev/labs/commerce/order/core/order/infra/messaging/KafkaOrderEventPublisherIntegrationTest.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/core/order/infra/messaging/KafkaOrderEventPublisherIntegrationTest.java
@@ -1,0 +1,177 @@
+package dev.labs.commerce.order.core.order.infra.messaging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.labs.commerce.order.core.order.application.event.OrderAbortedEvent;
+import dev.labs.commerce.order.core.order.application.event.OrderExpiredEvent;
+import dev.labs.commerce.order.core.order.application.event.OrderPaidEvent;
+import dev.labs.commerce.order.support.AbstractIntegrationTest;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaOrderEventPublisherIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private KafkaOrderEventPublisher publisher;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value("${spring.cloud.stream.kafka.binder.brokers}")
+    private String bootstrapServers;
+
+    @Test
+    @DisplayName("publishOrderPaid는 트랜잭션 커밋 후 order.paid에 OrderPaidEvent envelope을 발행한다")
+    void publishOrderPaid_afterCommit_publishesEnvelopeToOrderPaidTopic() {
+        // given
+        String orderId = UUID.randomUUID().toString();
+        OrderPaidEvent event = new OrderPaidEvent(orderId, List.of(
+                new OrderPaidEvent.OrderItemPayload(1L, 2)));
+
+        try (Consumer<String, String> consumer = subscribingConsumer("order.paid")) {
+            // when
+            inTransaction(() -> publisher.publishOrderPaid(event));
+
+            // then
+            ConsumerRecord<String, String> record = pollForKey(consumer, orderId, Duration.ofSeconds(10));
+            assertThat(record).as("expected order.paid record with key %s", orderId).isNotNull();
+            JsonNode envelope = readJson(record.value());
+            assertThat(envelope.path("meta").path("eventType").asText()).isEqualTo("OrderPaidEvent");
+            assertThat(envelope.path("payload").path("orderId").asText()).isEqualTo(orderId);
+            assertThat(envelope.path("payload").path("items")).hasSize(1);
+            assertThat(envelope.path("payload").path("items").get(0).path("productId").asLong()).isEqualTo(1L);
+            assertThat(envelope.path("payload").path("items").get(0).path("quantity").asInt()).isEqualTo(2);
+        }
+    }
+
+    @Test
+    @DisplayName("publishOrderAborted는 트랜잭션 커밋 후 order.aborted에 OrderAbortedEvent envelope을 발행한다")
+    void publishOrderAborted_afterCommit_publishesEnvelopeToOrderAbortedTopic() {
+        // given
+        String orderId = UUID.randomUUID().toString();
+        OrderAbortedEvent event = new OrderAbortedEvent(orderId, List.of(
+                new OrderAbortedEvent.OrderItemPayload(1L, 2)));
+
+        try (Consumer<String, String> consumer = subscribingConsumer("order.aborted")) {
+            // when
+            inTransaction(() -> publisher.publishOrderAborted(event));
+
+            // then
+            ConsumerRecord<String, String> record = pollForKey(consumer, orderId, Duration.ofSeconds(10));
+            assertThat(record).as("expected order.aborted record with key %s", orderId).isNotNull();
+            JsonNode envelope = readJson(record.value());
+            assertThat(envelope.path("meta").path("eventType").asText()).isEqualTo("OrderAbortedEvent");
+            assertThat(envelope.path("payload").path("orderId").asText()).isEqualTo(orderId);
+            assertThat(envelope.path("payload").path("items")).hasSize(1);
+        }
+    }
+
+    @Test
+    @DisplayName("publishOrderExpired는 트랜잭션 커밋 후 order.expired에 OrderExpiredEvent envelope을 발행한다")
+    void publishOrderExpired_afterCommit_publishesEnvelopeToOrderExpiredTopic() {
+        // given
+        String orderId = UUID.randomUUID().toString();
+        OrderExpiredEvent event = new OrderExpiredEvent(orderId, List.of(
+                new OrderExpiredEvent.OrderItemPayload(1L, 2)));
+
+        try (Consumer<String, String> consumer = subscribingConsumer("order.expired")) {
+            // when
+            inTransaction(() -> publisher.publishOrderExpired(event));
+
+            // then
+            ConsumerRecord<String, String> record = pollForKey(consumer, orderId, Duration.ofSeconds(10));
+            assertThat(record).as("expected order.expired record with key %s", orderId).isNotNull();
+            JsonNode envelope = readJson(record.value());
+            assertThat(envelope.path("meta").path("eventType").asText()).isEqualTo("OrderExpiredEvent");
+            assertThat(envelope.path("payload").path("orderId").asText()).isEqualTo(orderId);
+            assertThat(envelope.path("payload").path("items")).hasSize(1);
+        }
+    }
+
+    @Test
+    @DisplayName("트랜잭션이 롤백되면 publish 호출이 있어도 메시지가 발행되지 않는다")
+    void publish_whenTransactionRollsBack_doesNotPublish() {
+        // given
+        String orderId = UUID.randomUUID().toString();
+        OrderPaidEvent event = new OrderPaidEvent(orderId, List.of(
+                new OrderPaidEvent.OrderItemPayload(1L, 2)));
+
+        try (Consumer<String, String> consumer = subscribingConsumer("order.paid")) {
+            // when : 호출 후 트랜잭션을 롤백
+            TransactionTemplate template = new TransactionTemplate(transactionManager);
+            template.execute(status -> {
+                publisher.publishOrderPaid(event);
+                status.setRollbackOnly();
+                return null;
+            });
+
+            // then : 2초 동안 우리 orderId의 메시지는 도착하지 않음
+            ConsumerRecord<String, String> record = pollForKey(consumer, orderId, Duration.ofSeconds(2));
+            assertThat(record).as("rollback 시 발행 안 되어야 함").isNull();
+        }
+    }
+
+    // --- helpers ---
+
+    private void inTransaction(Runnable body) {
+        new TransactionTemplate(transactionManager).execute(status -> {
+            body.run();
+            return null;
+        });
+    }
+
+    private ConsumerRecord<String, String> pollForKey(
+            Consumer<String, String> consumer, String key, Duration timeout) {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(500));
+            for (ConsumerRecord<String, String> r : records) {
+                if (key.equals(r.key())) {
+                    return r;
+                }
+            }
+        }
+        return null;
+    }
+
+    private Consumer<String, String> subscribingConsumer(String topic) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-listener-" + UUID.randomUUID());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        Consumer<String, String> consumer = new DefaultKafkaConsumerFactory<>(
+                props, new StringDeserializer(), new StringDeserializer()).createConsumer();
+        consumer.subscribe(List.of(topic));
+        consumer.poll(Duration.ofMillis(500));
+        return consumer;
+    }
+
+    private JsonNode readJson(String value) {
+        try {
+            return objectMapper.readTree(value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/service/order-service/src/test/java/dev/labs/commerce/order/support/AbstractIntegrationTest.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/support/AbstractIntegrationTest.java
@@ -1,0 +1,39 @@
+package dev.labs.commerce.order.support;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+// 통합테스트 베이스. PostgreSQL/Kafka 컨테이너를 static으로 공유한다.
+// TODO: 두 번째 서비스가 통합테스트를 추가하면 shared/common testFixtures로 이동.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Testcontainers
+@ActiveProfiles("integration-test")
+public abstract class AbstractIntegrationTest {
+
+    @Container
+    protected static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgres:16-alpine"))
+            .withInitScript("init-test-schema.sql")
+            .withReuse(true);
+
+    @Container
+    protected static final ConfluentKafkaContainer KAFKA = new ConfluentKafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.6.1"))
+            .withReuse(true);
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url",
+                () -> POSTGRES.getJdbcUrl() + "?currentSchema=order");
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+    }
+}

--- a/service/order-service/src/test/resources/application-integration-test.yml
+++ b/service/order-service/src/test/resources/application-integration-test.yml
@@ -1,0 +1,35 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  cloud:
+    stream:
+      bindings:
+        onStockReservationFailed-in-0:
+          group: "order-service-it-${random.uuid}"
+        onPaymentInitialized-in-0:
+          group: "order-service-it-${random.uuid}"
+        onPaymentApproved-in-0:
+          group: "order-service-it-${random.uuid}"
+        onPaymentFailed-in-0:
+          group: "order-service-it-${random.uuid}"
+        onPaymentExpired-in-0:
+          group: "order-service-it-${random.uuid}"
+
+order:
+  expiry:
+    pending-expiry-minutes: 99999
+
+service:
+  client:
+    product:
+      base-url: http://localhost:1
+      connect-timeout: 1000
+      read-timeout: 1000
+
+logging:
+  level:
+    org.testcontainers: INFO
+    com.github.dockerjava: WARN
+    org.apache.kafka: WARN
+    dev.labs.commerce.order: DEBUG

--- a/service/order-service/src/test/resources/init-test-schema.sql
+++ b/service/order-service/src/test/resources/init-test-schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS "order";


### PR DESCRIPTION
## 배경

- Kafka 기반 이벤트 흐름이 실제로 브로커를 거쳐 DB까지 일관되게 닿는가를 검증하기 위한 테스트 코드 작성

## 변경 사항

### 통합테스트 인프라

- Postgres 16 / Confluent Kafka Testcontainers 기반 테스트 인프라 설정
- 테스트 설정 : 격리된 컨슈머 그룹(`${random.uuid}`), `ddl-auto: create-drop`, 스케줄러 비활성화
    - `init-test-schema.sql` — production과 동일한 `order` 스키마 사전 생성

### 작성 테스트 케이스

- `InventoryEventsConsumerIntegrationTest`
  - 해피 패스: `stock.reservation.failed` → 주문 ABORTED 전이
  - 멱등성: 이미 ABORTED인 주문에 이벤트 재도착 시 상태 불변
  - 회복력: 존재하지 않는 orderId 이벤트가 와도 후속 정상 이벤트는 처리됨
- `PaymentEventsConsumerIntegrationTest`
  - `payment.{initialized|approved|failed|expired}` 각각의 상태 전이
  - `payment.approved` 케이스는 outbound `order.paid` envelope 셰이프까지 검증
- `KafkaOrderEventPublisherIntegrationTest` (4 시나리오)
  - 3종 publish 메서드의 envelope 발행 + 토픽/key/payload 검증
  - 트랜잭션 롤백 시 미발행 검증 (`afterCommit` 동기화 정확성)