### PR TITLE
컨슈머 DLT 라우팅 도입 

### DIFF
--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -27,3 +27,19 @@
 `PgGatewayRouter`가 결제 요청의 `PgProvider` 값 기반으로 구현체를 라우팅하므로, 실제 PG 구현체 추가 시 기존 코드 변경 없음.
 
 결제 초기화 시 `idempotencyKey` 중복 여부를 사전 검사해, 네트워크 재시도로 동일 요청이 재전송되어도 이중 결제 미발생.
+
+## Dead Letter Topic (DLT)
+
+order-service의 Kafka 컨슈머 5종은 처리 실패 시 Spring Cloud Stream 기본 재시도(3회 backoff)
+후 메시지를 `<원본>.DLT` 토픽으로 라우팅한다. 메시지 손실을 방지하고 사후 추적/재처리 가능.
+
+| 원본 토픽 | DLT 토픽 |
+|---|---|
+| `stock.reservation.failed` | `stock.reservation.failed.DLT` |
+| `payment.initialized` | `payment.initialized.DLT` |
+| `payment.approved` | `payment.approved.DLT` |
+| `payment.failed` | `payment.failed.DLT` |
+| `payment.expired` | `payment.expired.DLT` |
+
+- 페이로드는 원본 그대로 보존되고, 헤더에 실패 metadata(예외 stacktrace, 원본 토픽, 시도 횟수)가 추가된다.
+- DLT 라우팅 동작은 `InventoryEventsConsumerIntegrationTest`에서 통합테스트로 검증.

--- a/service/order-service/src/main/resources/application.yml
+++ b/service/order-service/src/main/resources/application.yml
@@ -27,6 +27,27 @@ spring:
       kafka:
         binder:
           brokers: localhost:20023
+        bindings:
+          onStockReservationFailed-in-0:
+            consumer:
+              enableDlq: true
+              dlqName: stock.reservation.failed.DLT
+          onPaymentInitialized-in-0:
+            consumer:
+              enableDlq: true
+              dlqName: payment.initialized.DLT
+          onPaymentApproved-in-0:
+            consumer:
+              enableDlq: true
+              dlqName: payment.approved.DLT
+          onPaymentFailed-in-0:
+            consumer:
+              enableDlq: true
+              dlqName: payment.failed.DLT
+          onPaymentExpired-in-0:
+            consumer:
+              enableDlq: true
+              dlqName: payment.expired.DLT
       bindings:
         order-aborted-out-0:
           destination: order.aborted

--- a/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
+++ b/service/order-service/src/test/java/dev/labs/commerce/order/api/messaging/InventoryEventsConsumerIntegrationTest.java
@@ -1,5 +1,6 @@
 package dev.labs.commerce.order.api.messaging;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.labs.commerce.order.core.order.domain.OrderStatus;
@@ -7,7 +8,12 @@ import dev.labs.commerce.order.core.order.domain.SalesOrder;
 import dev.labs.commerce.order.core.order.domain.SalesOrderRepository;
 import dev.labs.commerce.order.core.order.domain.fixture.SalesOrderFixture;
 import dev.labs.commerce.order.support.AbstractIntegrationTest;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
@@ -17,12 +23,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -39,6 +47,9 @@ class InventoryEventsConsumerIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Value("${spring.cloud.stream.kafka.binder.brokers}")
+    private String bootstrapServers;
 
     @Test
     @DisplayName("재고 예약 실패 이벤트가 도착하면 해당 주문이 ABORTED로 전이된다")
@@ -71,20 +82,36 @@ class InventoryEventsConsumerIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 주문 이벤트가 와도 후속 정상 이벤트는 처리된다")
-    void unknownOrder_doesNotBlockSubsequentMessages() {
+    @DisplayName("처리 실패한 메시지는 DLT로 라우팅되고 후속 정상 메시지는 처리된다")
+    void unknownOrder_routesToDltAndDoesNotBlockSubsequentMessages() {
+        // given
         SalesOrder normalOrder = salesOrderRepository.saveAndFlush(
                 SalesOrderFixture.builder().withSample().build());
         String unknownOrderId = "unknown-" + UUID.randomUUID();
-        sendEvent(unknownOrderId);
-        sendEvent(normalOrder.getOrderId());
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofMillis(500))
-                .untilAsserted(() -> {
-                    SalesOrder reloaded = salesOrderRepository.findById(normalOrder.getOrderId()).orElseThrow();
-                    assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
-                });
+
+        try (Consumer<String, String> dltConsumer = subscribingConsumer("stock.reservation.failed.DLT")) {
+            // when : 잘못된 메시지를 먼저, 정상 메시지를 뒤에 발송
+            sendEvent(unknownOrderId);
+            sendEvent(normalOrder.getOrderId());
+
+            // then : 정상 주문은 결국 ABORTED로 전이됨 (재시도 backoff 후)
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(30))
+                    .pollInterval(Duration.ofMillis(500))
+                    .untilAsserted(() -> {
+                        SalesOrder reloaded = salesOrderRepository.findById(normalOrder.getOrderId()).orElseThrow();
+                        assertThat(reloaded.getStatus()).isEqualTo(OrderStatus.ABORTED);
+                    });
+
+            // then : 잘못된 메시지는 DLT 토픽에 페이로드 그대로 라우팅됨
+            ConsumerRecord<String, String> dltRecord = pollForKey(dltConsumer, unknownOrderId, Duration.ofSeconds(10));
+            assertThat(dltRecord).as("DLT에 unknown 메시지가 라우팅되어야 함").isNotNull();
+            JsonNode envelope = objectMapper.readTree(dltRecord.value());
+            assertThat(envelope.path("payload").path("orderId").asText()).isEqualTo(unknownOrderId);
+            assertThat(envelope.path("meta").path("eventType").asText()).isEqualTo("StockReservationFailedEvent");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void sendEvent(String orderId) {
@@ -113,6 +140,32 @@ class InventoryEventsConsumerIntegrationTest extends AbstractIntegrationTest {
                     SalesOrder reloaded = salesOrderRepository.findById(orderId).orElseThrow();
                     assertThat(reloaded.getStatus()).isEqualTo(expected);
                 });
+    }
+
+    private Consumer<String, String> subscribingConsumer(String topic) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-listener-" + UUID.randomUUID());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        Consumer<String, String> consumer = new DefaultKafkaConsumerFactory<>(
+                props, new StringDeserializer(), new StringDeserializer()).createConsumer();
+        consumer.subscribe(List.of(topic));
+        consumer.poll(Duration.ofMillis(500));
+        return consumer;
+    }
+
+    private ConsumerRecord<String, String> pollForKey(
+            Consumer<String, String> consumer, String key, Duration timeout) {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(500));
+            for (ConsumerRecord<String, String> r : records) {
+                if (key.equals(r.key())) {
+                    return r;
+                }
+            }
+        }
+        return null;
     }
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/service/order-service/src/test/resources/application-integration-test.yml
+++ b/service/order-service/src/test/resources/application-integration-test.yml
@@ -1,9 +1,26 @@
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 5s
+  datasource:
+    hikari:
+      connection-timeout: 3000
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
   cloud:
     stream:
+      kafka:
+        binder:
+          # 컨테이너 종료 후 끊긴 브로커 재연결 시도로 JVM 종료가 늘어지지 않도록 짧게
+          consumer-properties:
+            request.timeout.ms: 3000
+            default.api.timeout.ms: 3000
+            session.timeout.ms: 6000
+          producer-properties:
+            max.block.ms: 3000
+            delivery.timeout.ms: 3000
+            request.timeout.ms: 3000
+            retries: 0
       bindings:
         onStockReservationFailed-in-0:
           group: "order-service-it-${random.uuid}"


### PR DESCRIPTION
## 배경

- 처리 실패 메시지는 재시도 3회 후 **silent drop**의 한계를 보완하기위한 DLT 추가 : 우선 order-service 부터 도입

### 현재 동작의 위험

1. **데이터 일관성 단절** — Saga 보상 이벤트(`stock.reservation.failed` 등)가
   처리 중 예외로 사라지면, 발행자와 수신자의 상태 인식이 영구히 어긋남
2. **사후 추적 불가** — ERROR 로그 외에 그 메시지가 무엇이었는지 다시 들여다볼 방법 없음
3. **일시적 장애 복구 불가** — DB 슬로우 등으로 재시도 모두 실패한 메시지를 복구 후 재처리 불가

## 변경 사항

### DLT 활성화 — `application.yml`

`spring.cloud.stream.kafka.bindings.<binding>.consumer`에 `enableDlq: true` + `dlqName` 추가.

### 기타 변경 : 통합테스트 JVM 종료 지연 정리

테스트 완료 후 Testcontainer 종료된 Kafka/DB로 재연결 시도하며 JVM이 30초 이상 점유
- Kafka client `request.timeout.ms` / `delivery.timeout.ms` 3초로 단축
- `ddl-auto: create-drop` → `update` (종료 시 테이블 drop 시도 제거)
- Hikari `connection-timeout: 3s`
- `spring.lifecycle.timeout-per-shutdown-phase: 5s`

## PR 후속 작업 계획

- **Non-retriable 예외 즉시 DLT 라우팅** — `OrderNotFoundException`처럼 재시도해도
  영원히 실패할 예외는 1번 시도 후 즉시 DLT로. `ExceptionClassifier` 패턴 적용 필요
- **inventory-service / payment-service 컨슈머 DLT** — 같은 패턴 복제
- **DLT replay 도구** — DLT 메시지를 원본 토픽으로 다시 흘려보내는 CLI/관리 페이지
- **DLT 모니터링/알람** — 운영 인프라
- **Outbox 패턴** — 발행자 측 안전장치. DLT가 수신자 측을 메우는 것과 보완 관계
