### PR TITLE
inventory-service 통합테스트 추가

### DIFF
--- a/service/inventory-service/build.gradle.kts
+++ b/service/inventory-service/build.gradle.kts
@@ -36,6 +36,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:kafka")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+    testImplementation("org.awaitility:awaitility")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/service/inventory-service/src/test/java/dev/labs/commerce/inventory/api/messaging/OrderAbortedEventsConsumerIntegrationTest.java
+++ b/service/inventory-service/src/test/java/dev/labs/commerce/inventory/api/messaging/OrderAbortedEventsConsumerIntegrationTest.java
@@ -1,0 +1,107 @@
+package dev.labs.commerce.inventory.api.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.labs.commerce.inventory.core.inventory.domain.Actor;
+import dev.labs.commerce.inventory.core.inventory.domain.Inventory;
+import dev.labs.commerce.inventory.core.inventory.domain.InventoryHistory;
+import dev.labs.commerce.inventory.core.inventory.domain.InventoryHistoryRepository;
+import dev.labs.commerce.inventory.core.inventory.domain.InventoryRepository;
+import dev.labs.commerce.inventory.support.AbstractIntegrationTest;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(OrderAbortedEventsConsumerIntegrationTest.TestKafkaProducerConfig.class)
+class OrderAbortedEventsConsumerIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Autowired
+    private InventoryHistoryRepository inventoryHistoryRepository;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("OrderAbortedEvent가 도착하면 예약된 재고가 해제된다 (reserved 차감, available 복원)")
+    void event_consumed_releasesReservedStock() {
+        long productId = ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE);
+        String orderId = UUID.randomUUID().toString();
+
+        Inventory inventory = Inventory.create(productId);
+        inventory.increase(10);
+        inventory.reserve(5);
+        inventoryRepository.saveAndFlush(inventory);
+        inventoryHistoryRepository.saveAndFlush(
+                InventoryHistory.reserve(orderId, inventory, 5, Actor.ORDER_SERVICE));
+
+        sendEvent(orderId, productId, 5);
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    Inventory reloaded = inventoryRepository.findById(productId).orElseThrow();
+                    assertThat(reloaded.getTotalQuantity()).isEqualTo(10);
+                    assertThat(reloaded.getReservedQuantity()).isZero();
+                    assertThat(reloaded.getAvailableQuantity()).isEqualTo(10);
+                });
+    }
+
+    private void sendEvent(String orderId, long productId, int quantity) {
+        kafkaTemplate.send("order.aborted", orderId, buildEnvelopeJson(orderId, productId, quantity));
+    }
+
+    private String buildEnvelopeJson(String orderId, long productId, int quantity) {
+        ObjectNode envelope = objectMapper.createObjectNode();
+        ObjectNode meta = envelope.putObject("meta");
+        meta.put("eventId", UUID.randomUUID().toString());
+        meta.put("eventType", "OrderAbortedEvent");
+        meta.put("occurredAt", Instant.now().toString());
+        ObjectNode payload = envelope.putObject("payload");
+        payload.put("orderId", orderId);
+        ArrayNode items = payload.putArray("items");
+        ObjectNode item = items.addObject();
+        item.put("productId", productId);
+        item.put("quantity", quantity);
+        return envelope.toString();
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestKafkaProducerConfig {
+
+        @Bean
+        KafkaTemplate<String, String> testKafkaTemplate(
+                @Value("${spring.cloud.stream.kafka.binder.brokers}") String bootstrapServers) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(config));
+        }
+    }
+}

--- a/service/inventory-service/src/test/java/dev/labs/commerce/inventory/api/messaging/OrderExpiredEventsConsumerIntegrationTest.java
+++ b/service/inventory-service/src/test/java/dev/labs/commerce/inventory/api/messaging/OrderExpiredEventsConsumerIntegrationTest.java
@@ -1,0 +1,107 @@
+package dev.labs.commerce.inventory.api.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.labs.commerce.inventory.core.inventory.domain.Actor;
+import dev.labs.commerce.inventory.core.inventory.domain.Inventory;
+import dev.labs.commerce.inventory.core.inventory.domain.InventoryHistory;
+import dev.labs.commerce.inventory.core.inventory.domain.InventoryHistoryRepository;
+import dev.labs.commerce.inventory.core.inventory.domain.InventoryRepository;
+import dev.labs.commerce.inventory.support.AbstractIntegrationTest;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(OrderExpiredEventsConsumerIntegrationTest.TestKafkaProducerConfig.class)
+class OrderExpiredEventsConsumerIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Autowired
+    private InventoryHistoryRepository inventoryHistoryRepository;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("OrderExpiredEvent가 도착하면 예약된 재고가 해제된다 (reserved 차감, available 복원)")
+    void event_consumed_releasesReservedStock() {
+        long productId = ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE);
+        String orderId = UUID.randomUUID().toString();
+
+        Inventory inventory = Inventory.create(productId);
+        inventory.increase(10);
+        inventory.reserve(5);
+        inventoryRepository.saveAndFlush(inventory);
+        inventoryHistoryRepository.saveAndFlush(
+                InventoryHistory.reserve(orderId, inventory, 5, Actor.ORDER_SERVICE));
+
+        sendEvent(orderId, productId, 5);
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    Inventory reloaded = inventoryRepository.findById(productId).orElseThrow();
+                    assertThat(reloaded.getTotalQuantity()).isEqualTo(10);
+                    assertThat(reloaded.getReservedQuantity()).isZero();
+                    assertThat(reloaded.getAvailableQuantity()).isEqualTo(10);
+                });
+    }
+
+    private void sendEvent(String orderId, long productId, int quantity) {
+        kafkaTemplate.send("order.expired", orderId, buildEnvelopeJson(orderId, productId, quantity));
+    }
+
+    private String buildEnvelopeJson(String orderId, long productId, int quantity) {
+        ObjectNode envelope = objectMapper.createObjectNode();
+        ObjectNode meta = envelope.putObject("meta");
+        meta.put("eventId", UUID.randomUUID().toString());
+        meta.put("eventType", "OrderExpiredEvent");
+        meta.put("occurredAt", Instant.now().toString());
+        ObjectNode payload = envelope.putObject("payload");
+        payload.put("orderId", orderId);
+        ArrayNode items = payload.putArray("items");
+        ObjectNode item = items.addObject();
+        item.put("productId", productId);
+        item.put("quantity", quantity);
+        return envelope.toString();
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestKafkaProducerConfig {
+
+        @Bean
+        KafkaTemplate<String, String> testKafkaTemplate(
+                @Value("${spring.cloud.stream.kafka.binder.brokers}") String bootstrapServers) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(config));
+        }
+    }
+}

--- a/service/inventory-service/src/test/java/dev/labs/commerce/inventory/api/messaging/PaymentEventsConsumerIntegrationTest.java
+++ b/service/inventory-service/src/test/java/dev/labs/commerce/inventory/api/messaging/PaymentEventsConsumerIntegrationTest.java
@@ -1,0 +1,97 @@
+package dev.labs.commerce.inventory.api.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.labs.commerce.inventory.core.inventory.domain.Inventory;
+import dev.labs.commerce.inventory.core.inventory.domain.InventoryRepository;
+import dev.labs.commerce.inventory.support.AbstractIntegrationTest;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(PaymentEventsConsumerIntegrationTest.TestKafkaProducerConfig.class)
+class PaymentEventsConsumerIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("OrderPaidEvent가 도착하면 예약된 재고가 확정된다 (reserved/total 차감)")
+    void event_consumed_confirmsReservedStock() {
+        long productId = ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE);
+        Inventory inventory = Inventory.create(productId);
+        inventory.increase(10);
+        inventory.reserve(5);
+        inventoryRepository.saveAndFlush(inventory);
+
+        String orderId = UUID.randomUUID().toString();
+        sendEvent(orderId, productId, 5);
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    Inventory reloaded = inventoryRepository.findById(productId).orElseThrow();
+                    assertThat(reloaded.getTotalQuantity()).isEqualTo(5);
+                    assertThat(reloaded.getReservedQuantity()).isZero();
+                });
+    }
+
+    private void sendEvent(String orderId, long productId, int quantity) {
+        kafkaTemplate.send("order.paid", orderId, buildEnvelopeJson(orderId, productId, quantity));
+    }
+
+    private String buildEnvelopeJson(String orderId, long productId, int quantity) {
+        ObjectNode envelope = objectMapper.createObjectNode();
+        ObjectNode meta = envelope.putObject("meta");
+        meta.put("eventId", UUID.randomUUID().toString());
+        meta.put("eventType", "OrderPaidEvent");
+        meta.put("occurredAt", Instant.now().toString());
+        ObjectNode payload = envelope.putObject("payload");
+        payload.put("orderId", orderId);
+        ArrayNode items = payload.putArray("items");
+        ObjectNode item = items.addObject();
+        item.put("productId", productId);
+        item.put("quantity", quantity);
+        return envelope.toString();
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestKafkaProducerConfig {
+
+        @Bean
+        KafkaTemplate<String, String> testKafkaTemplate(
+                @Value("${spring.cloud.stream.kafka.binder.brokers}") String bootstrapServers) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(config));
+        }
+    }
+}

--- a/service/inventory-service/src/test/java/dev/labs/commerce/inventory/api/messaging/ProductEventsConsumerIntegrationTest.java
+++ b/service/inventory-service/src/test/java/dev/labs/commerce/inventory/api/messaging/ProductEventsConsumerIntegrationTest.java
@@ -1,0 +1,89 @@
+package dev.labs.commerce.inventory.api.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.labs.commerce.inventory.core.inventory.domain.Inventory;
+import dev.labs.commerce.inventory.core.inventory.domain.InventoryRepository;
+import dev.labs.commerce.inventory.support.AbstractIntegrationTest;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(ProductEventsConsumerIntegrationTest.TestKafkaProducerConfig.class)
+class ProductEventsConsumerIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("ProductRegisteredEvent가 도착하면 inventory row가 생성된다")
+    void event_consumed_createsInventoryRow() {
+        long productId = ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE);
+
+        sendEvent(productId);
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    Optional<Inventory> inventory = inventoryRepository.findById(productId);
+                    assertThat(inventory).isPresent();
+                    assertThat(inventory.get().getTotalQuantity()).isZero();
+                    assertThat(inventory.get().getReservedQuantity()).isZero();
+                });
+    }
+
+    private void sendEvent(long productId) {
+        kafkaTemplate.send("product.registered", String.valueOf(productId), buildEnvelopeJson(productId));
+    }
+
+    private String buildEnvelopeJson(long productId) {
+        ObjectNode envelope = objectMapper.createObjectNode();
+        ObjectNode meta = envelope.putObject("meta");
+        meta.put("eventId", UUID.randomUUID().toString());
+        meta.put("eventType", "ProductRegisteredEvent");
+        meta.put("occurredAt", Instant.now().toString());
+        ObjectNode payload = envelope.putObject("payload");
+        payload.put("productId", productId);
+        return envelope.toString();
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestKafkaProducerConfig {
+
+        @Bean
+        KafkaTemplate<String, String> testKafkaTemplate(
+                @Value("${spring.cloud.stream.kafka.binder.brokers}") String bootstrapServers) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(config));
+        }
+    }
+}

--- a/service/inventory-service/src/test/java/dev/labs/commerce/inventory/support/AbstractIntegrationTest.java
+++ b/service/inventory-service/src/test/java/dev/labs/commerce/inventory/support/AbstractIntegrationTest.java
@@ -1,0 +1,37 @@
+package dev.labs.commerce.inventory.support;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Testcontainers
+@ActiveProfiles("integration-test")
+public abstract class AbstractIntegrationTest {
+
+    @Container
+    protected static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgres:16-alpine"))
+            .withInitScript("init-test-schema.sql")
+            .withReuse(true);
+
+    @Container
+    protected static final ConfluentKafkaContainer KAFKA = new ConfluentKafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.6.1"))
+            .withReuse(true);
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url",
+                () -> POSTGRES.getJdbcUrl() + "?currentSchema=inventory");
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+    }
+}

--- a/service/inventory-service/src/test/resources/application-integration-test.yml
+++ b/service/inventory-service/src/test/resources/application-integration-test.yml
@@ -1,0 +1,39 @@
+spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 5s
+  datasource:
+    hikari:
+      connection-timeout: 3000
+  jpa:
+    hibernate:
+      ddl-auto: update
+  cloud:
+    stream:
+      kafka:
+        binder:
+          # 컨테이너 종료 후 끊긴 브로커 재연결 시도로 JVM 종료가 늘어지지 않도록 짧게
+          consumer-properties:
+            request.timeout.ms: 3000
+            default.api.timeout.ms: 3000
+            session.timeout.ms: 6000
+          producer-properties:
+            max.block.ms: 3000
+            delivery.timeout.ms: 3000
+            request.timeout.ms: 3000
+            retries: 0
+      bindings:
+        onProductEvents-in-0:
+          group: "inventory-service-it-${random.uuid}"
+        onOrderAbortedEvents-in-0:
+          group: "inventory-service-it-${random.uuid}"
+        onOrderExpiredEvents-in-0:
+          group: "inventory-service-it-${random.uuid}"
+        onOrderPaidEvents-in-0:
+          group: "inventory-service-it-${random.uuid}"
+
+logging:
+  level:
+    org.testcontainers: INFO
+    com.github.dockerjava: WARN
+    org.apache.kafka: WARN
+    dev.labs.commerce.inventory: DEBUG

--- a/service/inventory-service/src/test/resources/init-test-schema.sql
+++ b/service/inventory-service/src/test/resources/init-test-schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS inventory;


### PR DESCRIPTION
## 배경

- inventory-service의 시스템에서 상태 변경(예약/해제/확정)에 대한 통합 테스트 추가
    - 메시지가 실제로 브로커를 거쳐 DB까지 일관되게 닿는지 검증할 수단 부재
- 후속 작업으로 컨슈머 DLT 도입 예정


## 작업 사항
 
### 통합테스트 인프라

- Postgres 16 / Confluent Kafka Testcontainers 기반 테스트 인프라 설정
- 테스트 설정 : 격리된 컨슈머 그룹(`${random.uuid}`), `ddl-auto: update`, Kafka/Hikari 종료 타임아웃 단축
  - `init-test-schema.sql` — production과 동일한 `inventory` 스키마 사전 생성
- order-service의 `AbstractIntegrationTest`를 그대로 복제 (TODO: shared/common testFixtures 추출은 별도 PR)

### 작성 테스트 케이스 (정상 경로)

- `ProductEventsConsumerIntegrationTest`
  - `product.registered` 수신 → 신규 inventory row 생성 검증
- `PaymentEventsConsumerIntegrationTest`
  - `order.paid` 수신 → 예약 재고 확정 (`reservedQuantity`/`totalQuantity` 동시 차감)
- `OrderAbortedEventsConsumerIntegrationTest`
  - `order.aborted` 수신 → RESERVE 이력 전제, 예약 해제 (`reservedQuantity` 차감 / `availableQuantity` 복원)
- `OrderExpiredEventsConsumerIntegrationTest`
  - `order.expired` 수신 → 보상 흐름이 abort와 동일하게 동작함을 검증
  
## 후속 작업

- REST 컨트롤러 통합 테스트
- inventory-service 컨슈머 DLT 도입