### PR TITLE
inventory-service 컨슈머 DLT 도입

### DIFF
--- a/service/inventory-service/src/main/resources/application.yml
+++ b/service/inventory-service/src/main/resources/application.yml
@@ -27,6 +27,23 @@ spring:
       kafka:
         binder:
           brokers: localhost:20023
+        bindings:
+          onProductEvents-in-0:
+            consumer:
+              enableDlq: true
+              dlqName: product.registered.DLT
+          onOrderAbortedEvents-in-0:
+            consumer:
+              enableDlq: true
+              dlqName: order.aborted.DLT
+          onOrderExpiredEvents-in-0:
+            consumer:
+              enableDlq: true
+              dlqName: order.expired.DLT
+          onOrderPaidEvents-in-0:
+            consumer:
+              enableDlq: true
+              dlqName: order.paid.DLT
       bindings:
         onProductEvents-in-0:
           destination: product.registered


### PR DESCRIPTION
## 배경

- inventory-service의 4개 컨슈머에도 DLT 도입

## 변경 사항

### DLT 활성화

application.yml 설정에 `spring.cloud.stream.kafka.bindings.<binding>.consumer`에 `enableDlq: true` + `dlqName: <원본>.DLT` 추가.

- `onProductEvents-in-0` → `product.registered.DLT`
- `onOrderAbortedEvents-in-0` → `order.aborted.DLT`
- `onOrderExpiredEvents-in-0` → `order.expired.DLT`
- `onOrderPaidEvents-in-0` → `order.paid.DLT`

### (NOTE)DLT 라우팅 검증 테스트 미포함

- inventory 도메인 컨슈머(register/release/confirm)는 모두 멱등 분기로 자연스러운 실패를 흡수 → 현재는 영구 실패 시나리오 부재
- 기존 happy-path / 멱등 통합 테스트가 통과한다는 사실이 "DLT 도입 후에도 정상 처리에 영향 없음"의 회귀 검증 역할
